### PR TITLE
2 little possible typos correction

### DIFF
--- a/dao/phase-zero.adoc
+++ b/dao/phase-zero.adoc
@@ -286,7 +286,7 @@ _Status:_ *pending.* See https://github.com/bisq-network/dao/issues/11 for detai
 
 === Define bonded contributor roles
 
-We enumerate and define the roles necessary to operate, maintain and administrate the Bisq project, Bisq network and Bisq DAO, such that responsibilities can be transferred from founders to other reputable contributors. Because each of these of these roles require a degree of trust, filling the role requires putting up a BSQ bond. Initially, founders will use their BSQ stake to bond into these roles, and will then transfer those roles to contributors who (a) wish to take the role over and (b) have earned sufficient BSQ to do so.
+We enumerate and define the roles necessary to operate, maintain and administrate the Bisq project, Bisq network and Bisq DAO, such that responsibilities can be transferred from founders to other reputable contributors. Because each of these roles requires a degree of trust, filling the role requires putting up a BSQ bond. Initially, founders will use their BSQ stake to bond into these roles, and will then transfer those roles to contributors who (a) wish to take the role over and (b) have earned sufficient BSQ to do so.
 
 _Status:_ *in progress.* Each role has been enumerated in the form of a GitHub issue in the <<roles-repo>>, and we continue to add to and modify these roles as appropriate. Bonding is not yet in place for any role.
 
@@ -425,7 +425,7 @@ See <<founder-use-cases>>.
 
 == Bonded contributor roles [[bonded-contributor-roles]]
 
-A _bonded contributor_ is a stakeholder who has put up a bond in BSQ in order to assume a _high-trust_ role within the DAO. High-trust roles are those that require privileged access such a password or private key to perform, and more generally include any duties that can cause harm to the Bisq network or project if carried out incorrectly. As protection against malfeasance and gross negligence, BSQ bonds may be confiscated (burned) in part or in whole through stakeholder voting. In compensation for making their BSQ illiquid and incurring confiscation risk, bonded contributors earn interest in BSQ on their bonds; in compensation for carrying out the specific duties of their role, bonded contributors earn BSQ via the same compensation request process that applies to all other (non-bonded) contributors.
+A _bonded contributor_ is a stakeholder who has put up a bond in BSQ in order to assume a _high-trust_ role within the DAO. High-trust roles are those that require privileged access such as a password or private key to perform, and more generally include any duties that can cause harm to the Bisq network or project if carried out incorrectly. As protection against malfeasance and gross negligence, BSQ bonds may be confiscated (burned) in part or in whole through stakeholder voting. In compensation for making their BSQ illiquid and incurring confiscation risk, bonded contributors earn interest in BSQ on their bonds; in compensation for carrying out the specific duties of their role, bonded contributors earn BSQ via the same compensation request process that applies to all other (non-bonded) contributors.
 
 While there are many specific bonded contributor roles, most fall into one of the categories below.
 

--- a/getting-started-review.adoc
+++ b/getting-started-review.adoc
@@ -22,7 +22,20 @@ Unlike most exchanges, Bisq doesn’t run a centralized server for making and ta
 
 
 This means that if you want to use the Bisq Network, you’ve got to download and run the software too!
-This means that if you want to use the Bisq Network, you’ve got to download and run the software too! Your computer becomes a member of the decentralized trading website.
+
+This means that if you want to use the Bisq Network, you’ve got to download and run the software too! Your computer becomes a member of the decentralized and robust trading website.
+
+
+Once the installer is finished
+
+Once the installation is finished
+
+
+It’ll take a few moments to open as it connects to Tor and syncs with Bisq’s peer-to-peer trading network.
+
+It’ll take a few moments to open as it connects to Tor and syncs with Bisq’s peer-to-peer trading network nodes.
+
+
 
 
 

--- a/getting-started-review.adoc
+++ b/getting-started-review.adoc
@@ -18,11 +18,10 @@ Maybe insert a carriage return before Optional
 
 Unlike most exchanges, Bisq doesn’t run a centralized server for making and taking offers, so trading on a website isn’t possible.
 
-Unlike most exchanges, Bisq doesn’t run a centralized server for making and taking offers, so trading on a centralized website isn’t possible.
+Unlike most exchanges, Bisq doesn’t run a centralized server for making and taking offers, so trading on a centralized website is neither wanted and neither possible.
 
 
 This means that if you want to use the Bisq Network, you’ve got to download and run the software too!
-
 This means that if you want to use the Bisq Network, you’ve got to download and run the software too! Your computer becomes a member of the decentralized trading website.
 
 

--- a/getting-started-review.adoc
+++ b/getting-started-review.adoc
@@ -16,6 +16,14 @@ To run Bisq, download and install it from the Bisq downloads page. Optional: bef
 Maybe insert a carriage return before Optional
 
 
+Unlike most exchanges, Bisq doesn’t run a centralized server for making and taking offers, so trading on a website isn’t possible.
+
+Unlike most exchanges, Bisq doesn’t run a centralized server for making and taking offers, so trading on a centralized website isn’t possible.
+
+
+This means that if you want to use the Bisq Network, you’ve got to download and run the software too!
+
+This means that if you want to use the Bisq Network, you’ve got to download and run the software too! Your computer becomes a member of the decentralized trading website.
 
 
 

--- a/getting-started-review.adoc
+++ b/getting-started-review.adoc
@@ -1,3 +1,10 @@
 = Getting Started with Bisq
 
-COMING SOON. Subscribe to https://github.com/bisq-network/bisq-docs/issues/37[bisq-network/bisq-docs#37] for updates.
+1st sentence = original material
+
+2nd sentence = suggestion
+
+the only constraint is that one side of each Bisq trade must always be bitcoin.
+
+the only constraint is (at the moment) that one side of each Bisq trade must always be bitcoin.
+

--- a/getting-started-review.adoc
+++ b/getting-started-review.adoc
@@ -1,0 +1,3 @@
+= Getting Started with Bisq
+
+COMING SOON. Subscribe to https://github.com/bisq-network/bisq-docs/issues/37[bisq-network/bisq-docs#37] for updates.

--- a/getting-started-review.adoc
+++ b/getting-started-review.adoc
@@ -1,5 +1,7 @@
 = Getting Started with Bisq
 
+From : https://github.com/m52go/bisq-docs/blob/getting-started/getting-started.adoc
+
 1st sentence = original material
 
 2nd sentence = suggestion
@@ -7,4 +9,13 @@
 the only constraint is that one side of each Bisq trade must always be bitcoin.
 
 the only constraint is (at the moment) that one side of each Bisq trade must always be bitcoin.
+
+
+To run Bisq, download and install it from the Bisq downloads page. Optional: before installing, verify the signatures of the 
+
+Maybe insert a carriage return before Optional
+
+
+
+
 

--- a/intro.adoc
+++ b/intro.adoc
@@ -79,4 +79,4 @@ These and other differences result in a key tradeoff for Bisq users--one in whic
  - Download and install Bisq at https://bisq.network/downloads
  - Get started trading with a https://www.youtube.com/watch?v=9JW25wXnPls&list=PLFH5SztL5cYMOm7IpvA2WkrSF3VscndPM[tutorial video]
  - Ask questions in the https://bisq.community[Bisq Forum] or https://bisq.network/slack-invite[Slack workspace]
- - Stay in touch by following https://twitter.com/bisq-network[@bisq_network] on Twitter
+ - Stay in touch by following https://twitter.com/bisq_network[@bisq_network] on Twitter


### PR DESCRIPTION
2 little possible typos correction 

Because each of these of these roles require a degree of trust, 
Because each of these roles requires a degree of trust, 

High-trust roles are those that require privileged access such a password or private key to perform
High-trust roles are those that require privileged access such as a password or private key to perform

(Apologies if doing something wrong, I'm a very noob with github)
Homard
