### PR TITLE
Expand docs index into a comprehensive table of contents

### DIFF
--- a/contributor-checklist.adoc
+++ b/contributor-checklist.adoc
@@ -1,4 +1,6 @@
 = Contributor Checklist
+:toc: left
+:sectanchors:
 
 So you're interested in contributing to Bisq--welcome! This checklist will get you plugged in and productive quickly as possible.
 

--- a/contributor-checklist.adoc
+++ b/contributor-checklist.adoc
@@ -1,4 +1,4 @@
-= New Contributor Checklist
+= Contributor Checklist
 
 So you're interested in contributing to Bisq--welcome! This checklist will get you plugged in and productive quickly as possible.
 
@@ -18,9 +18,9 @@ This can mean anything from fixing typos in documentation, to answering question
 
  * [ ] Introduce yourself in the `#general` channel. Say a bit about your skills and interests. This will help others point you in the right direction.
 
- * [ ] Join the `#github` channel and request an invite to the https://github.com/bisq-network[@bisq-network] organization. An admin will get you set up. Doing this makes it possible to assign you to GitHub issues.
+ * [ ] Join the `#github` channel and request an invite to the https://github.com/bisq-network[@bisq-network] organization. An admin will get you set up. Doing this makes it possible to add you to the https://github.com/orgs/bisq-network/teams/contributors[@bisq-network/contributors] team and to assign you to GitHub issues.
 
- * [ ] After accepting your GitHub invitation, consider changing your https://github.com/orgs/bisq-network/people[membership visibility] from private to public. This helps others know at a glance roughly how many contributors are involved with Bisq.
+ * [ ] After accepting your GitHub invitation, please change your https://github.com/orgs/bisq-network/people[membership visibility] from `private` to `public`. This helps others know at a glance roughly how many contributors are involved with Bisq.
 
  * [ ] Explore the other channels in Slack, and join the ones that are of interest to you. For a start, we recommend joining `#proposals`, `#roles`, `#compensation`, and `#dev` (if you're a developer).
 

--- a/index.adoc
+++ b/index.adoc
@@ -1,24 +1,32 @@
 = Bisq Network Documentation
+:toc: left
+:sectanchors:
 
- * *_User Docs_*
- ** <<intro#, Introduction>> — Learn what Bisq is, why it exists and how it works
- ** <<getting-started#, Getting Started>> — Go from zero to trading in 15 minutes
- ** <<secure-wallet#, Secure Your Wallet>> — Keep your bitcoin safe
+== User Docs
 
- * *_Contributor Docs_*
- ** <<contributor-checklist#, New contributor checklist>>
- ** <<proposals#, Proposals>>
- ** <<exchange/howto/list-asset#, How to list an asset>>
- ** <<manual-dispute-payout#, How to issue a manual dispute payout>>
- ** <<exchange/howto/run-seednode#, How to run a seednode>>
- ** <<exchange/howto/run-price-relay-node#, How to run a pricenode>>
+ * <<intro#, Introduction>> — Learn what Bisq is, why it exists and how it works
+ * <<getting-started#, Getting Started>> — Go from zero to trading in 15 minutes
+ * <<secure-wallet#, Secure Your Wallet>> — Keep your bitcoin safe
 
- * *_Papers_*
- ** <<dao/phase-zero#, Phase Zero: A plan for bootstrapping the Bisq DAO>>
+== Contributor Docs
 
- * *_Specifications_*
- ** <<dao/specification#, Bisq DAO technical specification>>
- ** <<payment-account-age-witness#, Payment account age witness specification>>
- ** https://docs.google.com/document/d/1DXEVEfk4x1qN6QgIcb2PjZwU4m7W6ib49wCdktMMjLw/edit#heading=h.4nbd0q1s77uq[Bisq arbitration and mediation system] (GDoc)
+ * <<contributor-checklist#, New contributor checklist>>
+ * <<proposals#, Proposals>>
+ * <<exchange/howto/list-asset#, How to list an asset>>
+ * <<manual-dispute-payout#, How to issue a manual dispute payout>>
+ * <<exchange/howto/run-seednode#, How to run a seednode>>
+ * <<exchange/howto/run-price-relay-node#, How to run a pricenode>>
 
- * *_<<archive#, Archive>>_*
+== Papers
+
+ * <<dao/phase-zero#, Phase Zero: A plan for bootstrapping the Bisq DAO>>
+
+== Specifications
+
+ * <<dao/specification#, Bisq DAO technical specification>>
+ * <<payment-account-age-witness#, Payment account age witness specification>>
+ * https://docs.google.com/document/d/1DXEVEfk4x1qN6QgIcb2PjZwU4m7W6ib49wCdktMMjLw/edit#heading=h.4nbd0q1s77uq[Bisq arbitration and mediation system] (GDoc)
+
+== Archive
+
+ * <<archive#, Archived docs>>

--- a/index.adoc
+++ b/index.adoc
@@ -30,8 +30,8 @@ Docs without hyperlinks haven't been written yet. If you want to write one, <<co
 
 === Features
 
- * Payment Methods — _Explore 20+ supported fiat currency payment methods, from Alipay to Zelle_
- * Altcoins — _Explore 100+ supported cryptocurrencies, tokens and assets_
+ * Payment Methods — _Explore https://bisq.network/faq/#paymentmethods[20+] supported fiat currency payment methods, from Alipay to Zelle_
+ * Altcoins — _Explore https://bisq.network/faq/#altcoins[100+] supported cryptocurrencies, tokens and assets_
 
 === Ecosystem
 

--- a/index.adoc
+++ b/index.adoc
@@ -1,6 +1,7 @@
 = Bisq Network Documentation
 :toc: left
 :sectanchors:
+:docinfo: private
 
 == User Docs
 

--- a/index.adoc
+++ b/index.adoc
@@ -3,15 +3,52 @@
 :sectanchors:
 :docinfo: private
 
+[TIP]
+.Brand new to Bisq?
+====
+Welcome! Start with the <<essentials>>. You'll be up and trading quickly.
+====
+
+[NOTE]
+.These docs are a work in progress (and you can help)
+====
+Docs without hyperlinks haven't been written yet. If you want to write one, <<contributor-checklist#,let us know>>.
+====
+
 == User Docs
 
- * <<intro#, Introduction>> — Learn what Bisq is, why it exists and how it works
- * <<getting-started#, Getting Started>> — Go from zero to trading in 15 minutes
- * <<secure-wallet#, Secure Your Wallet>> — Keep your bitcoin safe
+=== Essentials
+
+ * <<intro#, Introduction>> — _Learn what Bisq is, why it exists and how it works_
+ * <<getting-started#, Getting Started>> — _Download, set up and start trading with Bisq in minutes_
+ * <<secure-wallet#, Secure Your Wallet>> — _Set a password and save your seed words to keep your bitcoin safe_
+ * Backup and Recovery — _Maintain backups to keep your settings and history safe_
+ * Staying Private — _Maximize control over your personal info and trading data_
+ * Trading and Arbitration Rules — _Know what's expected of you and others when trading_
+ * Fees and Security Deposits - _Understand how your bitcoin is used and kept safe when trading_
+ * Support — _Get help from other Bisq users and contributors_
+
+=== Features
+
+ * Payment Methods — _Explore 20+ supported fiat currency payment methods, from Alipay to Zelle_
+ * Altcoins — _Explore 100+ supported cryptocurrencies, tokens and assets_
+
+=== Ecosystem
+
+ * News and Announcements – _Stay informed with the Bisq https://github.com/bisq-network/proposals/issues/20[mailing list], https://twitter.com/bisq_network[Twitter], https://www.youtube.com/c/bisq-network[YouTube], https://www.facebook.com/bisqnetwork/[Facebook], etc_
+ * Media and Press — _Catch up on talks, interviews, podcasts and articles about Bisq_
+ * Chat and Discussion — _Connect with other users on the Bisq https://bisq.community[Forum], https://bisq.network/slack-invite[Slack], https://webchat.freenode.net/?channels=bisq[IRC], https://keybase.io/team/bisq[Keybase], etc_
+ * Charts and Data – _Explore Bisq https://markets.bisq.network[markets], https://bisq.network/volume[global volume],  https://coin.dance/volume/bisq/[regional volume], https://bisq.network/release-stats[release statistics], etc_
+ * Ratings and Reviews — _Read Bisq user experience reports and reviews on sites like https://www.cryptocompare.com/exchanges/bisq/[CryptoCompare]_
+
+=== Incubating Efforts
+
+ * Bisq HTTP API — _Automate trading and interact programmatically with your Bisq node_
+ * Bisq Mobile — _Operate your Bisq node remotely via a web/mobile frontend_
 
 == Contributor Docs
 
- * <<contributor-checklist#, New contributor checklist>>
+ * <<contributor-checklist#, Contributor Checklist>>
  * <<proposals#, Proposals>>
  * <<exchange/howto/list-asset#, How to list an asset>>
  * <<manual-dispute-payout#, How to issue a manual dispute payout>>

--- a/index.adoc
+++ b/index.adoc
@@ -36,7 +36,7 @@ Docs without hyperlinks haven't been written yet. If you want to write one, <<co
 === Ecosystem
 
  * News and Announcements – _Stay informed with the Bisq https://github.com/bisq-network/proposals/issues/20[mailing list], https://twitter.com/bisq_network[Twitter], https://www.youtube.com/c/bisq-network[YouTube], https://www.facebook.com/bisqnetwork/[Facebook], etc_
- * Media and Press — _Catch up on talks, interviews, podcasts and articles about Bisq_
+ * Media and Press — _Catch up on https://twitter.com/bisq_network/status/946723541298360320[talks, interviews, podcasts and articles] about Bisq_
  * Chat and Discussion — _Connect with other users on the Bisq https://bisq.community[Forum], https://bisq.network/slack-invite[Slack], https://webchat.freenode.net/?channels=bisq[IRC], https://keybase.io/team/bisq[Keybase], etc_
  * Charts and Data – _Explore Bisq https://markets.bisq.network[markets], https://bisq.network/volume[global volume],  https://coin.dance/volume/bisq/[regional volume], https://bisq.network/release-stats[release statistics], etc_
  * Ratings and Reviews — _Read Bisq user experience reports and reviews on sites like https://www.cryptocompare.com/exchanges/bisq/[CryptoCompare]_

--- a/intro.adoc
+++ b/intro.adoc
@@ -1,4 +1,5 @@
 = A Brief Introduction to Bisq
+:toc: left
 :sectanchors:
 
 video::Fv-eCchzBZA[youtube,start=113,end=1168,width=860,height=480,options="modest"]


### PR DESCRIPTION
@bisq-network/contributors, have a look at the Netlify deploy preview for this PR (you can find it in the "Checks" section below). In it, you'll see the main page of https://docs.bisq.network expanding to become an easy to use, comprehensive table of contents for all things Bisq.

It's broken down into major sections by audience, e.g. "User Docs" and "Contributor Docs", and from there, further broken down according to what these audiences are likely to need to know first, such as the "Essentials" that cover what Bisq is, how to get started trading, and so on.

Some of docs you see mentioned on the page don't exist yet. From the comment on commit 2f90e71:

> As explained in the new admonition at the top of the page, many of these
> docs have not yet been written, and therefore have no links. The idea is to
> publish this list of the docs we have _and_ the docs we want to have, such
> that users can get a sense of everything we want them to know about Bisq,
> even though it's not all ready to go yet, and such that contributors can
> get a sense of where they can add value by writing these incomplete docs.
>
> In subsequent commits, the same kind of 'fleshing out' will be done for the
> 'Contributor Docs' section of the index page.

There are certainly more as-yet-unwritten docs that could be called out here, but I find the current mix to be a good balance. Do feel free, however, to add comments about or submit pull requests for additional docs you think should be written.


An aside about the future of these docs
--------

As this new documentation approach progresses, my goal is to get to a place where we have a truly _documentation-driven_ approach to developing new Bisq software. Today, we write proposals for new ideas, and that's a great way to get initial validation whether a new component or major change to an existing component is a good idea in the first place. In the future, I'd like to develop a culture in which the first thing we do after a proposal, or possibly in conjunction with a proposal, is write the high-level documentation for the change being proposed. Going back to our recent definition of [delivered work](https://github.com/bisq-network/proposals/issues/19), if something is not documented, it effectively does not exist. I'd like to take this one step further now, and create a condition in which we write that documentation _before_ doing any substantive work, such that we are always operating from the _user's perspective_ in everything we do. Writing user documentation first is a tried-and-true approach to aligning on what matters most, to minimizing bikeshedding, and ultimately to making sure that we create valuable software that people actually want. Amazon has famously followed this approach, which they call "Working Backwards". I recommend reading AWS CTO Werner Vogels' blog post on the matter here: https://www.allthingsdistributed.com/2006/11/working_backwards.html.