### PR TITLE
Set toc and sectanchors attributes globally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ asciidoctor {
     }
 
     attributes 'source-highlighter': 'coderay',
+        toc                 : 'left',
+        sectanchors         : '',
         icons               : 'font',
         idprefix            : '',
         idseparator         : '-',

--- a/contributor-checklist.adoc
+++ b/contributor-checklist.adoc
@@ -1,6 +1,4 @@
 = Contributor Checklist
-:toc: left
-:sectanchors:
 
 So you're interested in contributing to Bisq--welcome! This checklist will get you plugged in and productive quickly as possible.
 

--- a/dao/overview.adoc
+++ b/dao/overview.adoc
@@ -1,10 +1,6 @@
 = Bisq DAO Overview
-:toc:
-:toc-placement!:
 
 NOTE: This overview of the Bisq DAO has been superseded by a new paper released on October 19th, 2017 titled <<phase-zero#, Phase Zero: A plan for bootstrapping the Bisq DAO>> Please refer to that document for more up to date information; this one will likely be removed soon.
-
-toc::[]
 
 == Introduction
 

--- a/dao/specification.adoc
+++ b/dao/specification.adoc
@@ -1,5 +1,4 @@
 = Bisq DAO technical specification
-:toc: left
 
 NOTE: This document is a detailed technical specification for the Bisq DAO and BSQ token. For a high-level overview and rationale, please see <<phase-zero#, Phase Zero: A plan for bootstrapping the Bisq DAO>>.
 

--- a/exchange/howto/add-alternative-base-currency.adoc
+++ b/exchange/howto/add-alternative-base-currency.adoc
@@ -1,5 +1,4 @@
 = How to add an alternative base currency
-:toc:
 
 == Introduction
 

--- a/exchange/howto/list-asset.adoc
+++ b/exchange/howto/list-asset.adoc
@@ -1,6 +1,4 @@
 = How to list an asset
-:toc:
-:sectanchors:
 
 == Introduction
 

--- a/exchange/howto/run-price-relay-node.adoc
+++ b/exchange/howto/run-price-relay-node.adoc
@@ -1,5 +1,4 @@
 = How to run a price relay node
-:toc:
 
 == Introduction
 

--- a/exchange/howto/run-seednode.adoc
+++ b/exchange/howto/run-seednode.adoc
@@ -1,5 +1,4 @@
 = How to run a seed node
-:toc:
 
 == Introduction
 

--- a/exchange/whitepaper.adoc
+++ b/exchange/whitepaper.adoc
@@ -1,14 +1,10 @@
 = Bisq - The peer-to-peer bitcoin exchange
-:toc:
 :toclevels: 4
-:toc-placement!:
 :uri-payment-protocol: images/payment-protocol.png
 :uri-risk-analysis: https://bisq.network/docs/risk-analysis.pdf
 :uri-arbitration-system: https://bisq.network/docs/arbitration-system.pdf
 
 NOTE: This document is the original Bisq whitepaper. On October 19th, 2017, we released a new paper titled <<../dao/phase-zero#,Phase Zero: A plan for bootstrapping the Bisq DAO>>. If you're new to Bisq and looking for a comprehensive overview of the project, we recommend reading the section titled <<../dao/phase-zero#Part-I,Understanding Bisq and the Bisq DAO>>, which largely replaces the content of this whitepaper.
-
-toc::[]
 
 == Introduction
 

--- a/getting-started.adoc
+++ b/getting-started.adoc
@@ -1,6 +1,4 @@
 = Getting Started with Bisq
-:toc: left
-:sectanchors:
 :imagesdir: images
 :!figure-caption:
 :btc-deposit: 0.01

--- a/index.adoc
+++ b/index.adoc
@@ -1,6 +1,4 @@
 = Bisq Network Documentation
-:toc: left
-:sectanchors:
 :docinfo: private
 
 [TIP]

--- a/intro.adoc
+++ b/intro.adoc
@@ -1,6 +1,4 @@
 = A Brief Introduction to Bisq
-:toc: left
-:sectanchors:
 
 video::Fv-eCchzBZA[youtube,start=113,end=1168,width=860,height=480,options="modest"]
 

--- a/manual-dispute-payout.adoc
+++ b/manual-dispute-payout.adoc
@@ -1,6 +1,4 @@
 = How to issue a manual dispute payout
-:toc: left
-:sectanchors:
 
 == Introduction
 

--- a/payment-account-age-witness.adoc
+++ b/payment-account-age-witness.adoc
@@ -1,6 +1,4 @@
 = Payment account age witness
-:toc: left
-:sectanchors:
 Manfred Karrer <mk@nucleo.io>
 2017-09-14
 

--- a/proposals.adoc
+++ b/proposals.adoc
@@ -1,6 +1,4 @@
 = Proposals
-:toc: left
-:sectanchors:
 
 Proposals are a means for suggesting specific changes to Bisq Network software components, infrastructure and processes. They are especially useful where awareness and agreement of other contributors is required in order for the change to be successfully implemented.
 

--- a/secure-wallet.adoc
+++ b/secure-wallet.adoc
@@ -1,6 +1,4 @@
 = Secure Your Wallet
-:toc: left
-:sectanchors:
 :imagesdir: images
 :!figure-caption:
 


### PR DESCRIPTION
This avoids the need to repeat these common attributes in each document
and also normalizes their application across all documents (which had
previously been somewhat inconsistent).