### PR TITLE
Produce 'Roles' doc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ asciidoctor {
         idprefix            : '',
         idseparator         : '-',
         docinfo1            : '',
-        'gh-org'            : 'https://github.com/bisq-network'
+        'gh-org'            : 'https://github.com/bisq-network',
+        'gh-team'           : 'https://github.com/orgs/bisq-network/teams'
 }
 
 build.dependsOn asciidoctor

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ asciidoctor {
         icons               : 'font',
         idprefix            : '',
         idseparator         : '-',
-        docinfo1            : ''
+        docinfo1            : '',
+        'gh-org'            : 'https://github.com/bisq-network'
 }
 
 build.dependsOn asciidoctor

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,8 @@ asciidoctor {
         idseparator         : '-',
         docinfo1            : '',
         'gh-org'            : 'https://github.com/bisq-network',
-        'gh-team'           : 'https://github.com/orgs/bisq-network/teams'
+        'gh-team'           : 'https://github.com/orgs/bisq-network/teams',
+        'role'              : 'https://github.com/bisq-network/roles/issues'
 }
 
 build.dependsOn asciidoctor

--- a/dao/phase-zero.adoc
+++ b/dao/phase-zero.adoc
@@ -425,27 +425,19 @@ See <<founder-use-cases>>.
 
 == Bonded contributor roles [[bonded-contributor-roles]]
 
-A _bonded contributor_ is a stakeholder who has put up a bond in BSQ in order to assume a _high-trust_ role within the DAO. High-trust roles are those that require privileged access such as a password or private key to perform, and more generally include any duties that can cause harm to the Bisq network or project if carried out incorrectly. As protection against malfeasance and gross negligence, BSQ bonds may be confiscated (burned) in part or in whole through stakeholder voting. In compensation for making their BSQ illiquid and incurring confiscation risk, bonded contributors earn interest in BSQ on their bonds; in compensation for carrying out the specific duties of their role, bonded contributors earn BSQ via the same compensation request process that applies to all other (non-bonded) contributors.
-
-While there are many specific bonded contributor roles, most fall into one of the categories below.
+NOTE: This section has been superseded by the <<../roles#, Roles>> document.
 
 === Maintainer
 
-A _maintainer_ is a bonded contributor responsible for a given repository in the <<bisq-network-org>>, including managing its issues, reviewing and merging pull requests and releasing new versions of the software in that repository.
-
-See <<maintainer-use-cases>>.
+NOTE: This section has been superseded by the <<../roles#maintainer, Maintainer>> section of the <<../roles#, Roles>> document.
 
 === Operator
 
-An _operator_ is a bonded contributor responsible for running ("operating") software that support the Bisq network. Examples include Bisq _seed node_ and _price node_ operators, the Bisq website operator, and the BSQ transaction explorer operator. Where practical, maintainer and operator roles may be played by the same contributor.
+NOTE: This section has been superseded by the <<../roles#operator, Operator>> section of the <<../roles#, Roles>> document.
 
 === Administrator
 
-An _administrator_ is a bonded contributor responsible for managing ("administering") applications and services that support the Bisq project. Examples include GitHub admin, DNS admin, Slack admin, IRC admin and Discourse (forum) admin.
-
-=== Other roles not listed here
-
-There are more than 30 bonded contributor roles in the Bisq project. See the <<roles-repo>> for a complete list.
+NOTE: This section has been superseded by the <<../roles#administrator, Administrator>> section of the <<../roles#, Roles>> document.
 
 
 = Appendix B: Resources [[Appendix-B]]
@@ -464,9 +456,11 @@ https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+org%3Abisq-network+label%3A
 
 https://github.com/bisq-network/compensation[https://github.com/bisq-network/compensation]
 
-=== roles repository and board [[roles-repo,bisq-network/roles repository]]
+=== roles repository [[roles-repo,bisq-network/roles repository]]
 
 https://github.com/bisq-network/roles[https://github.com/bisq-network/roles]
+
+See the <<../roles#, Roles>> document for full details.
 
 === proposals repository [[proposals-repo,bisq-network/proposals repository]]
 
@@ -580,30 +574,6 @@ NOTE: It is important to vote "no" if you believe a request should not be approv
 === issue the final BSQ genesis distribution on Bitcoin mainnet
 
 === modify this plan
-
-== As a bonded contributor, I can… [[bonded-contributor-use-cases,bonded contributor use cases]]
-
-=== earn interest on my BSQ bond
-
-=== transfer my role to the successor of my choosing
-
-== As a maintainer, I can… [[maintainer-use-cases,maintainer use cases]]
-
-=== post bounties
-
-In practice, "posting a bounty" simply means adding the `$BSQ bounty` label to a GitHub issue. Because maintainers are the only ones with write access to the repositories they maintain, they are the only ones with the ability to add this (or any other) label.
-
-The `$BSQ bounty` label should only be added to issues that are _ready for work_, meaning that they are already defined well enough to make it possible for a contributor to begin working on that bounty with a minimum amount of discussion.
-
-A well-defined bounty is one that clearly states a problem to be solved. If the desired solution is already known, the bounty should provide as much detail as necessary about that solution. If the solution is not already known, the maintainer may want to formulate the bounty as a request for a _proposal_ that can be reviewed and discussed, and then a subsequent bounty can address actually implementing that proposed solution.
-
-=== review and merge pull requests
-
-In accordance with the C4 process,footnoteref:[C4] all contributions to bisq-network repositories should come in the form of pull requests. Repository maintainers should review and comment on pull requests and merge them only if they are correct and well-formed.
-
-=== publish releases
-
-Maintainers are responsible for publishing releases of the software they maintain.
 
 == Post-phase zero use cases [[post-phase-zero-use-cases]]
 

--- a/index.adoc
+++ b/index.adoc
@@ -48,6 +48,7 @@ Docs without hyperlinks haven't been written yet. If you want to write one, <<co
 
  * <<contributor-checklist#, Contributor Checklist>>
  * <<proposals#, Proposals>>
+ * <<roles#, Roles>>
  * <<exchange/howto/list-asset#, How to list an asset>>
  * <<manual-dispute-payout#, How to issue a manual dispute payout>>
  * <<exchange/howto/run-seednode#, How to run a seednode>>

--- a/proposals.adoc
+++ b/proposals.adoc
@@ -1,51 +1,71 @@
 = Proposals
 
-Proposals are a means for suggesting specific changes to Bisq Network software components, infrastructure and processes. They are especially useful where awareness and agreement of other contributors is required in order for the change to be successfully implemented.
+Proposals are a means for suggesting changes to Bisq Network software components, infrastructure and processes.
 
 
 == Introduction
 
-The Bisq DAO is a flat organization, meaning that there is no command-and-control hierarchy available to make big decisions and carry them out.
+The Bisq DAO is a flat organization, with no command-and-control hierarchy available to make big decisions and carry them out. Usually this is not a problem, as most day-to-day changes happen without any need for organization-wide consensus. Certain kinds of changes, however, benefit from or even require it.
 
-Generally, this is not a problem, as the Bisq DAO is designed for contributors to operate permissionlessly and autonomously. Most day-to-day changes happen without any need for organization-wide consensus, but there are certain kinds of changes that benefit from or even require it. For such cases, what's needed is a mechanism that allows any contributor to _propose_ a change, and allows any and all other contributors to _review_ it in order to arrive at an IETF-style https://en.wikipedia.org/wiki/Rough_consensus[rough consensus] whether to proceed.
-
-_Proposals_ are that mechanism within the Bisq DAO, and this document covers everything that submitters, reviewers and maintainers need to know about the infrastructure, process and best practices around them.
+What's needed is a mechanism that allows any contributor to _propose_ a change, and all other contributors to _review_ it in order to arrive at an IETF-style rough consensus.footnote:[See link:https://en.wikipedia.org/wiki/Rough_consensus[]] _Proposals_ are that mechanism, and this document covers everything that participants need to know about the process.
 
 === What proposals are good for
 
-If you're thinking of creating an entire new Bisq component or making a significant change to an existing one, it's a good idea to submit a proposal first. Likewise, if you want to change something about the way contributors work together under the Bisq DAO, submit a proposal.
+ * Creating an entire new Bisq component or making a significant change to an existing one
+ * Changing something about the way contributors work together
 
 === What proposals are not good for
 
-For smaller changes to existing components, infrastructure or processes, where a broad consensus of contributors is not required, just submit an issue and/or pull request in the relevant repository. The maintainer of that repository will let you know if the change is too big or controversial, in which case they'll probably suggest you write a proposal. When in doubt, don't jump right to submitting a proposal. Have a conversation first. Chat with other contributors. See if they think a proposal is merited.
+ * Smaller changes to existing components, infrastructure or processes, where a broad consensus of contributors is not required
 
 
 == Infrastructure
 
 === GitHub
 
-Proposals are managed as GitHub issues in the https://github.com/bisq-network/proposals/issues[bisq-network/proposals] repository.
-
-TIP: If you're an active Bisq contributor, consider https://help.github.com/articles/watching-and-unwatching-repositories/[watching] this repository to be notified of new proposals and discussions around them. You can always https://help.github.com/articles/subscribing-to-and-unsubscribing-from-notifications/[unsubscribe] from specific issues you're not interested in.
+Proposals are managed as GitHub issues in the {gh-org}/proposals/issues[bisq-network/proposals] repository.
 
 === Slack
 
 The `#proposals` Slack channel is available for discussion and notifications about proposal issue activity.
 
 
-== Roles and responsibilities
+== Roles
 
 === Submitter
 
-The contributor(s) who write a proposal and carry it through to completion. **Submitters are 100% responsible for the success of their proposals.**
+The contributor(s) who write a proposal and carry it through to completion.
+
+**Submitters are 100% responsible for the success of their proposals.**
 
 === Reviewer
 
-Other contributors who read, discuss and react to proposals. **Any contributor _may_ review a proposal, but no contributor is obligated to do so.** This intentionally puts the onus on the submitter to ensure their proposal is relevant and well-written per the guidelines below.
+Other contributors who read, discuss and react to proposals.
+
+**Any contributor _may_ review a proposal, but no contributor is obligated to do so.** This intentionally puts the onus on the submitter to ensure their proposal is relevant and well-written per the <<guidelines>> below.
 
 === Maintainer
 
-The contributor(s) who have administrative rights over the `bisq-network/proposals` GitHub repository, monitor the `#proposals` Slack channel, enforce the process detailed below, and write https://github.com/bisq-network/roles/issues/30[monthly reports] on proposals activity. **Maintainers have no special authority to approve or reject proposals.**
+The contributor(s) responsible for proposals <<infrastructure>> and <<process>>.footnote:[See link:roles.html#maintainer[]]
+
+==== Role Issue
+
+{gh-org}/roles/issues/30[#30]
+
+==== Duties
+
+ * Enforce the proposals <<process>> detailed below.
+ * Monitor communications on the `#proposals` Slack channel.footnote:[See link:roles.html#communication[]]
+ * Keep this proposals documentation up to date.footnote:[See link:roles.html#documentation[]]
+ * Write a monthly report on the proposals maintainer <<role-issue>>.footnote:[See link:roles.html#reporting[]]
+
+==== Rights
+
+ * Write access to the {gh-org}/proposals[bisq-network/proposals] repository
+
+==== Owners
+
+See the <<role-issue>>
 
 
 == Process
@@ -67,7 +87,7 @@ A maintainer will quickly review your proposal and will either (a) assign it to 
 
 === Step 2. Review
 
-Once a proposal is submitted, a two-week review period follows. During this period, interested reviewers should read, discuss and ultimately react to the proposal as follows:
+Once a proposal is submitted, a two-week review period follows. During this period, interested reviewers should read, discuss and ultimately https://help.github.com/articles/about-conversations-on-github/#reacting-to-ideas-in-comments[react] to the proposal as follows:
 
  - 👍: I agree with the proposal and want to see it enacted
  - 😕: I am uncertain about the proposal and I need more information
@@ -79,7 +99,7 @@ If you do not understand or care about a given proposal, ignore it.
 
 Use comments on the proposal issue to discuss, ask questions, and get clarifications. Take lengthy discussions offline to Slack or elsewhere and then summarize them back on the issue.
 
-TIP: Remember that the proposal review process is all about reaching a _rough consensus,_ meaning that there is a broad agreement that the proposal should be enacted, and that any dissenting opinions have been addressed, though not necessarily fully resolved.
+NOTE: Remember that the proposal review process is all about reaching a _rough consensus,_ meaning that there is a broad agreement that the proposal should be enacted, and that any dissenting opinions have been addressed, though not necessarily fully resolved.
 
 === Step 3. Evaluate
 

--- a/proposals.adoc
+++ b/proposals.adoc
@@ -50,12 +50,12 @@ The contributor(s) responsible for proposals <<infrastructure>> and <<process>>.
 
 ==== Role Issue
 
-{gh-org}/roles/issues/30[#30]
+{gh-org}/roles/issues/30[bisq-network/roles#30] footnote:[See link:roles.html#issue[]]
 
 ==== Role Team
 :proposals-maintainers: {gh-team}/proposals-maintainers[@bisq-network/proposals-maintainers]
 
-{proposals-maintainers} footnote:[See link:roles.html#teams[]]
+{proposals-maintainers} footnote:[See link:roles.html#team[]]
 
 ==== Duties
 
@@ -66,13 +66,7 @@ The contributor(s) responsible for proposals <<infrastructure>> and <<process>>.
 
 ==== Rights
 
- * Membership in the {proposals-maintainers} team
- * `Maintainer` status in the {proposals-maintainers} team (primary owner only)
- * Write access to the {gh-org}/proposals[bisq-network/proposals] repository (through the {proposals-maintainers} team)
-
-==== Owners
-
-See the <<role-issue>>
+ * Write access to the {gh-org}/proposals[bisq-network/proposals] repository.
 
 
 == Process

--- a/proposals.adoc
+++ b/proposals.adoc
@@ -52,6 +52,11 @@ The contributor(s) responsible for proposals <<infrastructure>> and <<process>>.
 
 {gh-org}/roles/issues/30[#30]
 
+==== Role Team
+:proposals-maintainers: {gh-team}/proposals-maintainers[@bisq-network/proposals-maintainers]
+
+{proposals-maintainers} footnote:[See link:roles.html#teams[]]
+
 ==== Duties
 
  * Enforce the proposals <<process>> detailed below.
@@ -61,7 +66,9 @@ The contributor(s) responsible for proposals <<infrastructure>> and <<process>>.
 
 ==== Rights
 
- * Write access to the {gh-org}/proposals[bisq-network/proposals] repository
+ * Membership in the {proposals-maintainers} team
+ * `Maintainer` status in the {proposals-maintainers} team (primary owner only)
+ * Write access to the {gh-org}/proposals[bisq-network/proposals] repository (through the {proposals-maintainers} team)
 
 ==== Owners
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -1,15 +1,34 @@
-= Roles
+= Bisq DAO Roles
 
-Roles are the means by which responsibility over specific Bisq Network components, infrastructure and processes is delegated to individual contributors.
+Roles are the way contributors take responsibility for Bisq Network resources and processes.
 
 
 == Introduction
 
-The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many vital resources and processes that must be cared for by individuals. For example, someone must manage the DNS for the https://bisq.network[bisq.network] domain, someone must admininister the {gh-org}[bisq-network] GitHub organization, and so on.
+The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many vital resources and processes that must be cared for by individuals. For example, someone must manage the DNS for the `bisq.network` domain, someone must conduct monthly stakeholder voting, and so on.
 
-And because the Bisq DAO is not a volunteer organization, but one that compensates valuable contributions, it must be possible for stakeholders to assess how these resources and processes are being cared for over time so as to know whether and how much to compensate those in charge of them.
+What's needed is a mechanism that defines these various responsibilities, makes it clear who is responsible for each, and that includes a process for regular reporting and feedback. The system of _roles_ described below provides that mechanism.
 
-What's needed is a mechanism that defines each of these responsibilities, makes it clear who is responsible for them, and that includes a process for regular reporting and feedback. The system of roles described below provide that mechanism.
+
+== Characteristics
+
+=== Duties
+
+Actions that must be performed for a certain resource or process to function normally.
+
+For example, a repository maintainer's duties include merging pull requests in a timely fashion, and the website operator's duties include keeping the site available at all times.
+
+=== Rights
+
+Special permissions or other access required to perform the <<duties>> of a role.
+
+For example, a repository maintainer's rights include write permissions to their repository, and the website operator's rights include administrative access to site hosting infrastructure.
+
+=== Owners
+
+The individuals who have the <<rights>> required to perform the <<duties>> of a role.
+
+One owner is designated as _primary_ and any other owners are designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary is responsible for performing the <<duties>> of the role, while secondaries stand by, capable of taking over for the primary at any time.
 
 
 == Infrastructure
@@ -20,6 +39,7 @@ What's needed is a mechanism that defines each of these responsibilities, makes 
 
 Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] repository.
 
+////
  - Assignees used to track role ownership
  - Description field used to
    - Link to team
@@ -31,6 +51,7 @@ Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] rep
  - Anyone can subscribe to any issue or watch the whole repo to stay up to date with reporting
  - Labels used to
    - Indicate `help wanted`
+////
 
 ==== Teams
 
@@ -44,20 +65,6 @@ There is no "role documentation" per se, but rather there is documentation about
 
 Slack.
 
-
-== Anatomy of a role
-
-=== Duties
-
-A role's _duties_ are the activities that the role's owner must carry out in order to be compensated for their efforts. For example, repository maintainers must enforce review process and merge pull requests in a timely fashion, the website operator must keep the site up and running at all times, and so forth.
-
-=== Rights
-
-Most roles involve some special _rights,_ such as exclusive permissions or access to a given resource. For example, a maintainer of a bisq-network GitHub repository will have write permissions to that repository such that they can merge contributors' pull requests, the operator of the bisq.network website will have administrative access to the infrastructure that hosts the site, and so forth.
-
-=== Owners
-
-Each role has one or more _owners,_ with one being designated as _primary_ and others being designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary role owner is responsible for carrying out the day to day activities of that role, while secondary owners are standing by, fully capable of taking over for the primary owner in case of sickness or other incapacitation.
 
 
 == Common role duties

--- a/roles.adoc
+++ b/roles.adoc
@@ -126,6 +126,12 @@ The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.fo
 
 {gh-org}/issues/28[#28]
 
+[roles-maintainer-role-team]
+=== Role Team
+:roles-maintainers: {gh-team}/roles-maintainers[@bisq-network/roles-maintainers]
+
+{roles-maintainers} footnote:[See link:roles.html#teams[]]
+
 [roles-maintainer-duties]
 === Duties
 
@@ -137,7 +143,9 @@ The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.fo
 [roles-maintainer-rights]
 === Rights
 
- * Write access to the {gh-org}/roles[bisq-network/roles] repository
+ * Membership in the {roles-maintainers} team
+ * `Maintainer` status in the {roles-maintainers} team (primary owner only)
+ * Write access to the {gh-org}/roles[bisq-network/roles] repository (through the {roles-maintainers} team)
 
 [roles-maintainer-owners]
 === Owners

--- a/roles.adoc
+++ b/roles.adoc
@@ -1,73 +1,70 @@
-= Bisq DAO Roles
+= Roles
 
 Roles are the way contributors take responsibility for Bisq Network resources and processes.
 
 
 == Introduction
 
-The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many vital resources and processes that must be cared for by individuals. For example, someone must manage the DNS for the `bisq.network` domain, someone must conduct monthly stakeholder voting, and so on.
-
-What's needed is a mechanism that defines these various duties, makes it clear who is responsible for each, and that includes a process for regular reporting and feedback. The system of _roles_ described below provides such a mechanism.
+The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many resources and processes vital to the operation of the network that must be cared for by individuals. For example, someone must manage the DNS for the `bisq.network` domain, someone must conduct monthly stakeholder voting, and so on. What's needed is a mechanism that defines these various duties, makes it clear who is responsible for each, and that provides a process for regular reporting and feedback. The system of _roles_ described below is designed to meet this need, with a major design goal being maximizing decentralization and keeping the organization flat as it grows.
 
 
-[[characteristics]]
-== Characteristics of a role
+== Properties
+
+The following are properties common to all roles.
 
 === Duties
 
-Actions that must be performed for a certain resource or process to function normally.
+_Duties_ are actions that must be performed for a certain resource or process to function normally.
 
-For example, a repository maintainer's duties include merging pull requests in a timely fashion, and the website operator's duties include keeping the site available at all times.
+For example, a repository maintainer's duties include merging pull requests in a timely fashion, and a website operator's duties include keeping the site available at all times.
 
 === Rights
 
-Special permissions or other access required to perform the <<duties>> of a role.
+_Rights_ are special permissions or other access required to perform the <<duties>> of a role.
 
-For example, a repository maintainer's rights include write permissions to their repository, and the website operator's rights include administrative access to site hosting infrastructure.
+For example, a repository maintainer's rights include write permissions to their repository, and a website operator's rights include administrative access to site hosting infrastructure.
 
 === Owners
 
-Contributors who have the <<rights>> required to perform the <<duties>> of a role.
+_Owners_ are contributors who have the <<rights>> required to perform the <<duties>> of a role.
 
 One owner is designated as _primary_ and any other owners are designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary is responsible for performing the <<duties>> of the role, while secondaries stand by, capable of taking over for the primary at any time.
 
 
 == Infrastructure
 
+The following infrastructure is used to define and manage each role.
+
 === Docs
 
-There is no "role documentation" per se, but rather there is documentation about whatever component or infrastructure a given role is responsible for, and in that documentation, there is a section for the role.
+Each role should be documented at https://docs.bisq.network[docs.bisq.network], not in a document of its own, but in a _section_ of a document dedicated to the larger resource or process in question.
 
-=== GitHub
+For example, there is no "Proposals Maintainer" document, but rather a <<proposals#, Proposals>> document having a <<proposals#maintainer, Maintainer>> section within.
 
-==== Issues
+Each role's documentation should enumerate its <<duties>> and <<rights>> and link to its <<team>> and <<issue>>.
 
-Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] repository.
+=== Team
 
-////
- - Assignees used to track role ownership
- - Description field used to
-   - Link to team
-   - Indicate who is primary
-   - Link to role documentation
- - Comments used for
-   - monthly reporting
-   - customer feedback
- - Anyone can subscribe to any issue or watch the whole repo to stay up to date with reporting
- - Labels used to
-   - Indicate `help wanted`
-////
+Each role has a dedicated GitHub team where each of the role's <<owners>> are members. The team is used to manage access to GitHub repositories that role is responsible for and to send notifications to owners with @mentions in GitHub issues and pull requests.
 
-==== Teams
+For example, the {gh-team}/desktop-maintainers/members[@bisq-network/desktop-maintainers] team has write access to the {gh-org}/bisq-desktop[bisq-network/bisq-desktop] repository.
 
-Managed as GitHub Teams. For @mentions and to institutionalize thinking in terms of roles not individuals.
+The primary role owner is also assigned as the _maintainer_ of the GitHub team, such that they may manage the team without requiring the intervention of a GitHub admin.
 
-=== Slack
+=== Issue
 
-Slack.
+Each role has a dedicated GitHub issue in the {gh-org}/roles/issues[bisq-network/roles] repository.
+
+ - The **Assignees** field is used to track role ownership.
+ - The **Description** field is used to link to the role's <<docs>>, <<team>> and primary <<owners, Owner>>.
+ - **Comments** are used for <<report, reporting>> and feedback.
+
+See the {gh-org}/roles/issues/30[Proposals Maintainer] role issue for an example.
 
 
 == Types
+
+Most roles fit into one of the types below.
 
 === Maintainer
 
@@ -78,11 +75,13 @@ Slack.
 === Moderator
 
 
-== Common role duties
+== Common duties
 
-=== Reporting
+The following duties are common to all roles.
 
-Primary role <<owners>> should submit a _monthly report_ as a comment on their <<issues, Role Issue>>.footnote:[See {gh-org}/proposals/issues/13] The report should contain whatever information the owner believes would be valuable to other users, contributors and stakeholders. The comment should be formatted in Markdown as follows:
+=== Report
+
+Primary role <<owners>> should report once a month in the form of a comment on their <<issue>>.footnote:[See {gh-org}/proposals/issues/13] The report should contain whatever information the owner believes would be valuable to other users, contributors and stakeholders. The comment should be formatted in Markdown as follows:
 
 [source,markdown]
 ----
@@ -97,62 +96,52 @@ Where `<content>` is the content of the report itself, and `<number>` is the num
 
 Some roles may have nothing to report in a given month. In this case, a report should still be written stating that there is "nothing to report". https://github.com/bisq-network/roles/issues/18#issuecomment-393217596[Example].
 
-=== Communication
+=== Document
 
-Respond to issues in any repositories
+Primary role <<owners>> should document changes to their role by submitting pull requests to their role's <<docs>>.
 
-Respond to inquiries in Slack
+=== Communicate
 
-Generally means setting up notifications appropriately.
-
-=== Documentation
-
-Specifically, keeping your own role's documentation up to date
+Primary role <<owners>> should respond in a timely fashion to feedback comments on their role <<issue>>, issues created in their repositories, @mentions of their <<team>>, and questions in their Slack channel.
 
 
 == Compensation
 
+TODO
+
 
 == Bonding
 
-////
-In the section below, custom [[anchors]] are used for each section to disambiguate them from sections with the same name in the general documentation above about role issues, role teams, duties, rights and owners.
-////
+TODO
+
+
 [[roles-maintainer-role]]
 == The Roles Maintainer role
 
-The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.footnote:[See link:roles.html#maintainer[]]
+Roles Maintainers are the contributors responsible for the system of roles described throughout the rest of this document.
 
-[[roles-maintainer-role-issue]]
-=== Role Issue
+[[roles-maintainer-issue]]
+=== Issue
 
-{gh-org}/issues/28[#28]
+{gh-org}/roles/issues/28[bisq-network/roles#28]
 
-[[roles-maintainer-role-team]]
-=== Role Team
-:roles-maintainers: {gh-team}/roles-maintainers[@bisq-network/roles-maintainers]
+[[roles-maintainer-team]]
+=== Team
 
-{roles-maintainers} footnote:[See link:roles.html#teams[]]
+{gh-team}/roles-maintainers[@bisq-network/roles-maintainers]
 
 [[roles-maintainer-duties]]
 === Duties
 
- * Enforce the proposals <<processes>> detailed below.
- * Monitor communications on the `#roles` Slack channel.footnote:[See link:roles.html#communication[]]
- * Keep this roles documentation up to date.footnote:[See link:roles.html#documentation[]]
- * Write a monthly report on the roles maintainer <<roles-maintainer-role-issue>>.footnote:[See link:roles.html#reporting[]]
+ * Follow and enforce the roles <<processes>> detailed below.
+ * <<report>> monthly on the Roles Maintainer <<roles-maintainer-issue>>.
+ * <<document>> changes to roles <<processes>>.
+ * <<communicate>> in the `#roles` Slack channel.
 
 [[roles-maintainer-rights]]
 === Rights
 
- * Membership in the {roles-maintainers} team
- * `Maintainer` status in the {roles-maintainers} team (primary owner only)
- * Write access to the {gh-org}/roles[bisq-network/roles] repository (through the {roles-maintainers} team)
-
-[[roles-maintainer-owners]]
-=== Owners
-
-See the <<roles-maintainer-role-issue>>
+ * Write access to the {gh-org}/roles[bisq-network/roles] repository
 
 
 == Processes

--- a/roles.adoc
+++ b/roles.adoc
@@ -273,7 +273,7 @@ Typically, proposing a new role is one part of a larger proposal to introduce so
 
  . Discuss the idea informally with other contributors, e.g. via Slack.
  . Follow the <<proposals#, Proposals>> process to formally suggest the new resource or process.
- . Draft documentation for the new resource or process, including a section about the new role as a pull request to the {gh-org/bisq-docs[bisq-network/bisq-docs] repository.
+ . Draft documentation for the new resource or process, including a section about the new role as a pull request to the {gh-org}/bisq-docs[bisq-network/bisq-docs] repository.
 
 For example, see the {gh-org}/proposals/15[proposal to support Tor Relays] and the resulting {role}/72[Tor Relay Operator] role issue.
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -115,7 +115,9 @@ Specifically, keeping your own role's documentation up to date
 
 == Bonding
 
-
+////
+In the section below, custom [[anchors]] are used for each section to disambiguate them from sections with the same name in the general documentation above about role issues, role teams, duties, rights and owners.
+////
 [[roles-maintainer-role]]
 == The Roles Maintainer role
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -64,6 +64,21 @@ Each role has one or more _owners,_ with one being designated as _primary_ and o
 
 === Reporting
 
+Primary role <<owners>> should submit a _monthly report_ as a comment on their role's <<issues,issue>>.footnote:[See {gh-org}/proposals/issues/13] The report should contain whatever information the owner believes would be valuable to other users, contributors and stakeholders. The comment should be formatted in Markdown as follows:
+
+[source,markdown]
+----
+## YYYY.MM report
+
+<content>
+
+/cc bisq-network/compensation#<number>
+----
+
+Where `<content>` is the content of the report itself, and `<number>` is the number of that contributor's monthly compensation request. https://github.com/bisq-network/roles/issues/16#issuecomment-393852612[Example].
+
+Some roles may have nothing to report in a given month. In this case, a report should still be written stating that there is "nothing to report". https://github.com/bisq-network/roles/issues/18#issuecomment-393217596[Example].
+
 === Communication
 
 Respond to issues in any repositories

--- a/roles.adoc
+++ b/roles.adoc
@@ -112,7 +112,32 @@ Examples: {role}/19[Forum Operator], {role}/14[Bisq Pricenode Operator]
 
 === Administrator
 
+An _Administrator_ ('Admin') is a contributor responsible for managing a given resource.
+
+Examples: {role}/16[GitHub Admin], {role}/23[Slack Admin]
+
+==== Admin Duties
+
+ * Respond to change requests.
+
+==== Admin Rights
+
+ * Access to the administrative interface of the resource in question.
+
 === Moderator
+
+A _Moderator_ is a contributor responsible for enforcing process and standards in a given communications channel.
+
+Examples: {role}/37[Bitcointalk Moderator], {role}/25[Reddit Moderator]
+
+==== Moderator Duties
+
+ * Ensure discussions are on topic, civil, etc.
+ * Post key announcements in a timely fashion.
+
+==== Moderator Rights
+
+ * Moderator (or equivalent) status in the channel.
 
 
 == Common duties

--- a/roles.adoc
+++ b/roles.adoc
@@ -33,7 +33,7 @@ For example, a repository maintainer's rights include write permissions to their
 
 _Owners_ are contributors who have the <<rights>> required to perform the <<duties>> of a role.
 
-One owner is designated as _primary_ and any other owners are designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary is responsible for performing the <<duties>> of the role, while secondaries stand by, capable of taking over for the primary at any time.
+One owner is designated as _primary_ and any other owners are designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary is responsible for performing the <<duties>> of the role, while secondaries stand by, ready to take over for the primary at any time.
 
 
 == Infrastructure
@@ -44,13 +44,13 @@ The following infrastructure is used to define and manage each role.
 
 Each role should be documented at https://docs.bisq.network[docs.bisq.network], not in a document of its own, but in a _section_ of a document dedicated to the larger resource or process in question.
 
-For example, there is no "Proposals Maintainer" document, but rather a <<proposals#, Proposals>> document having a <<proposals#maintainer, Maintainer>> section within.
+For example, there is no "Proposals Maintainer" document, but rather there is a <<proposals#, Proposals>> document having a <<proposals#maintainer, Maintainer>> section within.
 
 Each role's documentation should enumerate its <<duties>> and <<rights>> and link to its <<team>> and <<issue>>.
 
 === Team
 
-Each role has a dedicated GitHub team where each of the role's <<owners>> are members. The team is used to manage access to GitHub repositories that role is responsible for and to send notifications to owners with @mentions in GitHub issues and pull requests.
+Each role has a dedicated GitHub team where each of the role's <<owners>> are members. The team is used to manage access to GitHub repositories that the role is responsible for and to send notifications to role owners with @mentions in GitHub issues and pull requests.
 
 For example, the {gh-team}/desktop-maintainers/members[@bisq-network/desktop-maintainers] team has write access to the {gh-org}/bisq-desktop[bisq-network/bisq-desktop] repository.
 
@@ -58,7 +58,7 @@ The primary role owner is also assigned as the _maintainer_ of the GitHub team, 
 
 === Issue
 
-Each role has a dedicated GitHub issue in the {gh-org}/roles/issues[bisq-network/roles] repository.
+Each role has a dedicated GitHub issue in the {gh-org}/roles/issues[bisq-network/roles] repository, wherein:
 
  - The **Assignees** field is used to track role ownership.
  - The **Description** field is used to link to the role's <<docs>>, <<team>> and primary <<owners, Owner>>.
@@ -81,7 +81,7 @@ Examples: {role}/63[Bisq Desktop Maintainer], {role}/30[Proposals Maintainer].
 
  * Merging or closing pull requests after sufficient review.
  * Tagging releases.
- * Keeping issues organized and to a minimum.
+ * Triaging incoming issues and keeping them organized over time.
 
 [IMPORTANT]
 .A Maintainer is not a Developer or a Reviewer

--- a/roles.adoc
+++ b/roles.adoc
@@ -75,7 +75,7 @@ Most roles fit into one of the types below.
 
 A _Maintainer_ is a contributor responsible for enforcing process in a given GitHub repository.
 
-Examples: {role}/63[Bisq Desktop Maintainer], {role}/30[Proposals Maintainer]
+Examples: {role}/63[Bisq Desktop Maintainer], {role}/30[Proposals Maintainer].
 
 ==== Maintainer Duties
 
@@ -101,7 +101,7 @@ The goal is to have as many competent contributors developing and reviewing as p
 
 An _Operator_ is a contributor responsible for keeping a given resource running and functioning normally.
 
-Examples: {role}/19[Forum Operator], {role}/14[Bisq Pricenode Operator]
+Examples: {role}/19[Forum Operator], {role}/14[Bisq Pricenode Operator].
 
 ==== Operator Duties
 
@@ -119,7 +119,7 @@ Examples: {role}/19[Forum Operator], {role}/14[Bisq Pricenode Operator]
 
 An _Administrator_ ('Admin') is a contributor responsible for managing a given resource.
 
-Examples: {role}/16[GitHub Admin], {role}/23[Slack Admin]
+Examples: {role}/16[GitHub Admin], {role}/23[Slack Admin].
 
 ==== Admin Duties
 
@@ -133,7 +133,7 @@ Examples: {role}/16[GitHub Admin], {role}/23[Slack Admin]
 
 A _Moderator_ is a contributor responsible for enforcing process and standards in a given communications channel.
 
-Examples: {role}/37[Bitcointalk Moderator], {role}/25[Reddit Moderator]
+Examples: {role}/37[Bitcointalk Moderator], {role}/25[Reddit Moderator].
 
 ==== Moderator Duties
 
@@ -258,7 +258,7 @@ Roles Maintainers are the contributors responsible for the system of roles descr
 [[roles-maintainer-rights]]
 === Rights
 
- * Write access to the {gh-org}/roles[bisq-network/roles] repository
+ * Write access to the {gh-org}/roles[bisq-network/roles] repository.
 
 
 == Processes
@@ -279,15 +279,15 @@ For example, see the {gh-org}/proposals/15[proposal to support Tor Relays] and t
 
 A primary role owner may add a secondary owner with the following steps:
 
- . Add them as a member of the role's GitHub <<team>>
- . Add them as an assignee to role's GitHub <<issue>>
+ . Add them as a member of the role's GitHub <<team>>.
+ . Add them as an assignee to role's GitHub <<issue>>.
  . Announce the change via a comment on the role's GitHub <<issue>>.
 
 === Transferring ownership
 
 A primary owner may transfer ownership to another with the following steps:
 
- . Grant the _maintainer_ role to the new primary in the role's GitHub <<team>>
- . Remove the _maintainer_ role from yourself
+ . Grant the _maintainer_ role to the new primary in the role's GitHub <<team>>.
+ . Remove the _maintainer_ role from yourself.
  . Update the role's GitHub <<issue>> to reflect the new primary owner.
  . Announce the change in a comment on the role's GitHub <<issue>>.

--- a/roles.adoc
+++ b/roles.adoc
@@ -211,12 +211,31 @@ Roles Maintainers are the contributors responsible for the system of roles descr
 
 == Processes
 
+The following are some common roles-related processes.
+
 === Proposing a new role
+
+Typically, proposing a new role is one part of a larger proposal to introduce some new resource or process.
+
+ . Discuss the idea informally with other contributors, e.g. via Slack.
+ . Follow the <<proposals#, Proposals>> process to formally suggest the new resource or process.
+ . Draft documentation for the new resource or process, including a section about the new role as a pull request to the {gh-org/bisq-docs[bisq-network/bisq-docs] repository.
+
+For example, see the {gh-org}/proposals/15[proposal to support Tor Relays] and the resulting {role}/72[Tor Relay Operator] role issue.
+
+=== Adding a secondary owner
+
+A primary role owner may add a secondary owner with the following steps:
+
+ . Add them as a member of the role's GitHub <<team>>
+ . Add them as an assignee to role's GitHub <<issue>>
+ . Announce the change via a comment on the role's GitHub <<issue>>.
 
 === Transferring ownership
 
-=== Changing primary / secondary status
+A primary owner may transfer ownership to another with the following steps:
 
-=== Adding a secondary
-
-=== Providing feedback to role owners
+ . Grant the _maintainer_ role to the new primary in the role's GitHub <<team>>
+ . Remove the _maintainer_ role from yourself
+ . Update the role's GitHub <<issue>> to reflect the new primary owner.
+ . Announce the change in a comment on the role's GitHub <<issue>>.

--- a/roles.adoc
+++ b/roles.adoc
@@ -78,19 +78,19 @@ Examples: {role}/63[Bisq Desktop Maintainer], {role}/30[Proposals Maintainer]
  * Tagging releases.
  * Keeping issues organized and to a minimum.
 
-==== Maintainer Rights
-
- * Write access to the repository they are responsible for.
-
 [IMPORTANT]
 .A Maintainer is not a Developer or a Reviewer
 ====
-The maintainer role is strictly about enforcing process. Development (submitting pull requests) is something any contributor can do. Likewise, review is open to contributors and is NOT the special duty of maintainers.
+Submitting and reviewing pull requests is something any contributor can do; neither are maintainer duties per se.
 
-This is particularly important from a compensation perspective. If you are a maintainer, do NOT group development and review activities under your maintainer role in your compensation requests. Rather, itemize your pull requests and reviews just like any other contributor would.
+This is particularly important from a compensation perspective. **If you are a maintainer, do NOT group your development and review activities together with your maintainer role in your compensation requests.** Rather, account for them separately like any other contributor would.
 
 The goal is to have as many competent contributors developing and reviewing as possible, not to load everything on the Maintiner. https://rfc.unprotocols.org/spec:1/C4/#21-preliminaries[C4] is the inspiration here, it's worth re-reading.
 ====
+
+==== Maintainer Rights
+
+ * Write access to the repository they are responsible for.
 
 === Operator
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -116,19 +116,6 @@ Specifically, keeping your own role's documentation up to date
 == Bonding
 
 
-== Processes
-
-=== Proposing a new role
-
-=== Transferring ownership
-
-=== Changing primary / secondary status
-
-=== Adding a secondary
-
-=== Providing feedback to role owners
-
-
 [roles-maintainer]
 == The Roles Maintainer role
 
@@ -156,3 +143,16 @@ The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.fo
 ==== Owners
 
 See the <<roles-maintainer-role-issue>>
+
+
+== Processes
+
+=== Proposing a new role
+
+=== Transferring ownership
+
+=== Changing primary / secondary status
+
+=== Adding a secondary
+
+=== Providing feedback to role owners

--- a/roles.adoc
+++ b/roles.adoc
@@ -142,26 +142,6 @@ All normal <<maintainter>>
 === Rights
 
 
-== Notes
-
-replace the proto-documentation we did for roles in the Phase Zero doc, particularly that found at docs.bisq.network/dao/phase-zero.html#bonded-contributor-roles
-
-capture the decisions we've made around roles in bisq-network/proposals#12 and bisq-network/proposals#13 and bisq-network/proposals#14
-
-document the way the bisq-network/roles repository works and document the responsibilities of the roles maintainer (bisq-network/roles#28).
-
-cover the relationship between role issues, GitHub teams, primary/secondary role owners
-
-document, or at least carve out a placeholder for documenting, the way bonding and BSQ interest payments will work for bonded contributor roles.
-
-document the process for creating a new role, which will likely involve submitting a proposal for a new role, similar to the way this one was done
-
-Update https://docs.bisq.network/dao/phase-zero.html#Appendix-A
-
-Close https://github.com/bisq-network/bisq-docs/issues/46
-
-Maintainer role must be fully separated from reviewer role. Maintainers validate that pull requests are correct, maintainers ensure that overall process is followed, maintainers give enough time for sufficient review, and then, maintainers merge pull requests. When somone is _reviewing_ a pull request, even if that person is a maintainer, they are not wearing their maintainer hat. They are wearing their _contributor_ hat. Maintainers do not review. See https://github.com/bisq-network/roles/issues/63#issuecomment-393453744 for counter-example of this. Reviewing puts too much on maintainers.
-
 ////
 .Example
 ----

--- a/roles.adoc
+++ b/roles.adoc
@@ -140,19 +140,3 @@ https://github.com/bisq-network/roles/issues/28
 All normal <<maintainter>>
 
 === Rights
-
-
-////
-.Example
-----
-DNS Admin
-
-Assignees: @cbeams, @ripcurlx
-Description:
-    Team: @bisq-network/dns-admins
-    Primary: @cbeams
-    Docs: https://docs.bisq.network/dns.html#admin
-----
-////
-
-TIP: Subscribe to individual role issues or watch the entire repository to stay up to date with role reports.

--- a/roles.adoc
+++ b/roles.adoc
@@ -33,6 +33,10 @@ One owner is designated as _primary_ and any other owners are designated as _sec
 
 == Infrastructure
 
+=== Docs
+
+There is no "role documentation" per se, but rather there is documentation about whatever component or infrastructure a given role is responsible for, and in that documentation, there is a section for the role.
+
 === GitHub
 
 ==== Issues
@@ -56,10 +60,6 @@ Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] rep
 ==== Teams
 
 Managed as GitHub Teams. For @mentions and to institutionalize thinking in terms of roles not individuals.
-
-=== Docs
-
-There is no "role documentation" per se, but rather there is documentation about whatever component or infrastructure a given role is responsible for, and in that documentation, there is a section for the role.
 
 === Slack
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -59,7 +59,7 @@ Each role has a dedicated GitHub issue in the {gh-org}/roles/issues[bisq-network
  - The **Description** field is used to link to the role's <<docs>>, <<team>> and primary <<owners, Owner>>.
  - **Comments** are used for <<report, reporting>> and feedback.
 
-See the {gh-org}/roles/issues/30[Proposals Maintainer] role issue for an example.
+See the {role}/30[Proposals Maintainer] role issue for an example.
 
 
 == Types
@@ -92,9 +92,9 @@ Primary role <<owners>> should report once a month in the form of a comment on t
 /cc bisq-network/compensation#<number>
 ----
 
-Where `<content>` is the content of the report itself, and `<number>` is the number of that contributor's monthly compensation request. https://github.com/bisq-network/roles/issues/16#issuecomment-393852612[Example].
+Where `<content>` is the content of the report itself, and `<number>` is the number of that contributor's monthly compensation request. {role}/16#issuecomment-393852612[Example].
 
-Some roles may have nothing to report in a given month. In this case, a report should still be written stating that there is "nothing to report". https://github.com/bisq-network/roles/issues/18#issuecomment-393217596[Example].
+Some roles may have nothing to report in a given month. In this case, a report should still be written stating that there is "nothing to report". {role}/18#issuecomment-393217596[Example].
 
 === Document
 
@@ -123,7 +123,7 @@ Roles Maintainers are the contributors responsible for the system of roles descr
 [[roles-maintainer-issue]]
 === Issue
 
-{gh-org}/roles/issues/28[bisq-network/roles#28]
+{role}/28[bisq-network/roles#28]
 
 [[roles-maintainer-team]]
 === Team

--- a/roles.adoc
+++ b/roles.adoc
@@ -1,8 +1,96 @@
 = Roles
 
-COMING SOON. Subscribe to https://github.com/bisq-network/bisq-docs/issues/46[bisq-network/bisq-docs#46] for updates, and in the meantime:
+Roles are the means by which responsibility over specific Bisq Network components, infrastructure and processes is delegated to individual contributors.
 
- * Read https://docs.bisq.network/dao/phase-zero.html#Appendix-A[Appendix A: Roles] of the Phase Zero doc
- * Browse the issues under the https://github.com/bisq-network/roles/issues[bisq-network/roles] repository
+
+== Introduction
+
+The Bisq DAO is a flat organization, with no hierarchical management and reporting infrastructure. At the same time, there are many resources and processes within the Bisq Network that require individuals to take responsibility and to be held accountable for those responsibilities.
+
+What's needed is a mechanism that defines each of these responsibilities, makes it clear who is responsible for which, and that includes a process for regular reporting and feedback. Roles provide that mechanism.
+
+
+== Infrastructure
+
+=== GitHub
+
+Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] repository.
+
+ - Assignees used to track role ownership
+ - Description field used to
+   - Link to team
+   - Indicate who is primary
+   - Link to role documentation
+ - Comments used for
+   - monthly reporting
+   - customer feedback
+ - Anyone can subscribe to any issue or watch the whole repo to stay up to date with reporting
+ - Labels used to
+   - Indicate `help wanted`
+
+=== Teams in the bisq-network GitHub organization
+Managed as GitHub Teams. For @mentions and to institutionalize thinking in terms of roles not individuals.
+
+=== Docs
+
+==== role documentation
+There is no "role documentation" per se, but rather there is documentation about whatever component or infrastructure a given role is responsible for, and in that documentation, there is a section for the role.
+
+=== Slack
+
+.Example
+----
+DNS Admin
+
+Assignees: @cbeams, @ripcurlx
+Description:
+    Team: @bisq-network/dns-admins
+    Primary: @cbeams
+    Docs: https://docs.bisq.network/dns.html#admin
+----
+
+
+
+
+
+== Role ownership
+
+=== primary / secondary role owners
+
+=== Privileges
+
+=== Duties
+
+==== Reporting
+
+
+== Common Role Types
+
+bonded contributor roles
+
+maintainer
+
+operator
+
+administrator
+
+moderator
+
+
+replace the proto-documentation we did for roles in the Phase Zero doc, particularly that found at docs.bisq.network/dao/phase-zero.html#bonded-contributor-roles
+
+capture the decisions we've made around roles in bisq-network/proposals#12 and bisq-network/proposals#13 and bisq-network/proposals#14
+
+document the way the bisq-network/roles repository works and document the responsibilities of the roles maintainer (bisq-network/roles#28).
+
+cover the relationship between role issues, GitHub teams, primary/secondary role owners
+
+document, or at least carve out a placeholder for documenting, the way bonding and BSQ interest payments will work for bonded contributor roles.
+
+document the process for creating a new role, which will likely involve submitting a proposal for a new role, similar to the way this one was done
+
+Update https://docs.bisq.network/dao/phase-zero.html#Appendix-A
+
+Close https://github.com/bisq-network/bisq-docs/issues/46
 
 Maintainer role must be fully separated from reviewer role. Maintainers validate that pull requests are correct, maintainers ensure that overall process is followed, maintainers give enough time for sufficient review, and then, maintainers merge pull requests. When somone is _reviewing_ a pull request, even if that person is a maintainer, they are not wearing their maintainer hat. They are wearing their _contributor_ hat. Maintainers do not review. See https://github.com/bisq-network/roles/issues/63#issuecomment-393453744 for counter-example of this. Reviewing puts too much on maintainers.

--- a/roles.adoc
+++ b/roles.adoc
@@ -54,7 +54,9 @@ Each role has a dedicated GitHub team where each of the role's <<owners>> are me
 
 For example, the {gh-team}/desktop-maintainers/members[@bisq-network/desktop-maintainers] team has write access to the {gh-org}/bisq-desktop[bisq-network/bisq-desktop] repository.
 
-The primary role owner is also assigned as the _maintainer_ of the GitHub team, such that they may manage the team without requiring the intervention of a GitHub admin.
+NOTE: GitHub teams are visible only to GitHub organization members. To join the {gh-org}[@bisq-network] org, see the <<contributor-checklist#, Contributor Checklist>>.
+
+The primary role owner is also assigned as the _maintainer_ of their role's GitHub team, such that they may manage the team without requiring the intervention of a GitHub admin.
 
 === Issue
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -64,7 +64,7 @@ Each role has a dedicated GitHub issue in the {gh-org}/roles/issues[bisq-network
 
  - The **Assignees** field is used to track role ownership.
  - The **Description** field is used to link to the role's <<docs>>, <<team>> and primary <<owners, Owner>>.
- - **Comments** are used for <<report, reporting>> and feedback.
+ - **Comments** are used for <<reporting>> and feedback.
 
 See the {role}/30[Proposals Maintainer] role issue for an example.
 
@@ -151,7 +151,7 @@ Examples: {role}/37[Bitcointalk Moderator], {role}/25[Reddit Moderator].
 
 The following duties are common to all roles.
 
-=== Report
+=== Reporting
 
 Primary role <<owners>> should report once a month in the form of a comment on their <<issue>>.footnote:[See {gh-org}/proposals/issues/13] The report should contain whatever information the owner believes would be valuable to other users, contributors and stakeholders. The comment should be formatted in Markdown as follows:
 
@@ -168,11 +168,11 @@ Where `<content>` is the content of the report itself, and `<number>` is the num
 
 Some roles may have nothing to report in a given month. In this case, a report should still be written stating that there is "nothing to report". {role}/18#issuecomment-393217596[Example].
 
-=== Document
+=== Documentation
 
 Primary role <<owners>> should document changes to their role by submitting pull requests to their role's <<docs>>.
 
-=== Communicate
+=== Communication
 
 Primary role <<owners>> should respond in a timely fashion to feedback comments on their role <<issue>>, issues created in their repositories, @mentions of their <<team>>, and questions in their Slack channel.
 
@@ -181,9 +181,9 @@ Primary role <<owners>> should respond in a timely fashion to feedback comments 
 
 Role owners should include a summary line item for each role they own in a monthly <<dao/phase-zero#how-to-request-compensation, compensation request>>. Each summary should include:
 
- * The name of the role,
- * a link to the owner's monthly <<report>> for that role, and
- * the total amount of BSQ being requested for performing the role's duties during that month.
+ . The name of the role,
+ . a link to the owner's monthly <<reporting, report>> for that role, and
+ . the total amount of BSQ being requested for performing the role's duties during that month.
 
 [example]
 .Per-role line items in a compensation request
@@ -253,9 +253,9 @@ Roles Maintainers are the contributors responsible for the system of roles descr
 === Duties
 
  * Follow and enforce the roles <<processes>> detailed below.
- * <<report>> monthly on the Roles Maintainer <<roles-maintainer-issue>>.
- * <<document>> changes to roles <<processes>>.
- * <<communicate>> in the `#roles` Slack channel.
+ * <<reporting, Report>> monthly on the Roles Maintainer <<roles-maintainer-issue>>.
+ * <<documentation, Document>> changes to roles <<processes>>.
+ * <<communication, Communicate>> in the `#roles` Slack channel.
 
 [[roles-maintainer-rights]]
 === Rights

--- a/roles.adoc
+++ b/roles.adoc
@@ -4,3 +4,5 @@ COMING SOON. Subscribe to https://github.com/bisq-network/bisq-docs/issues/46[bi
 
  * Read https://docs.bisq.network/dao/phase-zero.html#Appendix-A[Appendix A: Roles] of the Phase Zero doc
  * Browse the issues under the https://github.com/bisq-network/roles/issues[bisq-network/roles] repository
+
+Maintainer role must be fully separated from reviewer role. Maintainers validate that pull requests are correct, maintainers ensure that overall process is followed, maintainers give enough time for sufficient review, and then, maintainers merge pull requests. When somone is _reviewing_ a pull request, even if that person is a maintainer, they are not wearing their maintainer hat. They are wearing their _contributor_ hat. Maintainers do not review. See https://github.com/bisq-network/roles/issues/63#issuecomment-393453744 for counter-example of this. Reviewing puts too much on maintainers.

--- a/roles.adoc
+++ b/roles.adoc
@@ -277,7 +277,7 @@ Typically, proposing a new role is one part of a larger proposal to introduce so
 
 For example, see the {gh-org}/proposals/15[proposal to support Tor Relays] and the resulting {role}/72[Tor Relay Operator] role issue.
 
-=== Adding a secondary owner
+=== Adding a secondary role owner
 
 A primary role owner may add a secondary owner with the following steps:
 
@@ -285,7 +285,7 @@ A primary role owner may add a secondary owner with the following steps:
  . Add them as an assignee to role's GitHub <<issue>>.
  . Announce the change via a comment on the role's GitHub <<issue>>.
 
-=== Transferring ownership
+=== Transferring role ownership
 
 A primary owner may transfer ownership to another with the following steps:
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -83,9 +83,9 @@ Examples: {role}/63[Bisq Desktop Maintainer], {role}/30[Proposals Maintainer]
 ====
 Submitting and reviewing pull requests is something any contributor can do; neither are maintainer duties per se.
 
-This is particularly important from a compensation perspective. **If you are a maintainer, do NOT group your development and review activities together with your maintainer role in your compensation requests.** Rather, account for them separately like any other contributor would.
+This is particularly important from a <<compensation>> perspective. **If you are a maintainer, do NOT group your development and review activities together with your maintainer role in your compensation requests.** Rather, account for them separately like any other contributor would.
 
-The goal is to have as many competent contributors developing and reviewing as possible, not to load everything on the Maintiner. https://rfc.unprotocols.org/spec:1/C4/#21-preliminaries[C4] is the inspiration here, it's worth re-reading.
+The goal is to have as many competent contributors developing and reviewing as possible, not to load everything on the maintainer. https://rfc.unprotocols.org/spec:1/C4/#21-preliminaries[C4] is the inspiration here, it's worth (re-)reading.
 ====
 
 ==== Maintainer Rights
@@ -172,7 +172,52 @@ Primary role <<owners>> should respond in a timely fashion to feedback comments 
 
 == Compensation
 
-TODO
+Role owners should include a summary line item for each role they own in a monthly <<dao/phase-zero#how-to-request-compensation, compensation request>>. Each summary should include:
+
+ * The name of the role,
+ * a link to the owner's monthly <<report>> for that role, and
+ * the total amount of BSQ being requested for performing the role's duties during that month.
+
+[example]
+.Per-role line items in a compensation request
+====
+* Bisq Desktop Maintainer | https://github.com/bisq-network/roles/issues/63#issuecomment-401352998[bisq-network/roles#63 (comment)] | 350 BSQ
+* Bisq Seednode Operator | https://github.com/bisq-network/roles/issues/15#issuecomment-401547205[bisq-network/roles#15 (comment)] | 150 BSQ
+====
+
+NOTE: Secondary role owners should not submit monthly reports or compensation requests for a role unless they actually performed the duties of that role during that month.
+
+The amount of BSQ requested should include any hard costs (e.g. hosting) plus time and effort costs involved in performing the duties of the role. These costs should be detailed in the monthly report as follows:
+
+[example]
+.Monthly report for Bisq Desktop Maintainer
+====
+## 2018.07 report
+
+ * Regular duties | 150 BSQ
+ * Big issue cleanup | 200 BSQ
+
+Total: 350 BSQ
+
+/cc bisq-network/compensation#42
+====
+
+[example]
+.Monthly report for Bisq Seednode Maintainer
+====
+## 2018.07 report
+
+ * Hosting 2 nodes @ 50 USD/mo on Digital Ocean | 100 BSQ
+ * Upgrade nodes to v0.7.1 | 50 BSQ
+
+Total: 150 BSQ
+
+/cc bisq-network/compensation#42
+====
+
+The only work items that should be included in role compensation are those <<duties>> that can be performed _only_ by that role's owner. Everything else should be itemized independently.
+
+For example, as mentioned above in the <<maintainer-duties>> section, a repository maintainer's main duties are merging pull requests and triaging incoming issues. If the person playing the maintainer role submits their own pull requests, or performs reviews of others' pull requests, that work should NOT be grouped together with regular maintainer duties when putting together a compensation request. Rather, each PR submitted or reviewed should be called out separately as individual contributions.
 
 
 == Bonding

--- a/roles.adoc
+++ b/roles.adoc
@@ -5,7 +5,12 @@ Roles are the way contributors take responsibility for Bisq Network resources an
 
 == Introduction
 
-The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many resources and processes vital to the operation of the network that must be cared for by individuals. For example, someone must manage the DNS for the `bisq.network` domain, someone must conduct monthly stakeholder voting, and so on. What's needed is a mechanism that defines these various duties, makes it clear who is responsible for each, and that provides a process for regular reporting and feedback. The system of _roles_ described below is designed to meet this need, with a major design goal being maximizing decentralization and keeping the organization flat as it grows.
+There are many resources and processes vital to the operation of the Bisq Network that require ownership by individual contributors. For example, someone must merge pull requests into the `bisq-desktop` repository, someone must manage DNS for the `bisq.network` domain, someone must conduct monthly stakeholder voting, and so on.
+
+This document defines the system of _roles_ used within the Bisq DAO to enumerate, define and track each of these responsibilities. The system is designed with two major goals in mind:
+
+ . To maximize role owner autonomy in order to achieve <<dao/phase-zero#, Phase Zero>> decentralization goals.
+ . To maximize transparency such that DAO stakeholders can effectively review and vote on role owner compensation requests.
 
 
 == Properties

--- a/roles.adoc
+++ b/roles.adoc
@@ -116,23 +116,23 @@ Specifically, keeping your own role's documentation up to date
 == Bonding
 
 
-[roles-maintainer]
+[[roles-maintainer-role]]
 == The Roles Maintainer role
 
 The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.footnote:[See link:roles.html#maintainer[]]
 
-[roles-maintainer-role-issue]
+[[roles-maintainer-role-issue]]
 === Role Issue
 
 {gh-org}/issues/28[#28]
 
-[roles-maintainer-role-team]
+[[roles-maintainer-role-team]]
 === Role Team
 :roles-maintainers: {gh-team}/roles-maintainers[@bisq-network/roles-maintainers]
 
 {roles-maintainers} footnote:[See link:roles.html#teams[]]
 
-[roles-maintainer-duties]
+[[roles-maintainer-duties]]
 === Duties
 
  * Enforce the proposals <<processes>> detailed below.
@@ -140,14 +140,14 @@ The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.fo
  * Keep this roles documentation up to date.footnote:[See link:roles.html#documentation[]]
  * Write a monthly report on the roles maintainer <<roles-maintainer-role-issue>>.footnote:[See link:roles.html#reporting[]]
 
-[roles-maintainer-rights]
+[[roles-maintainer-rights]]
 === Rights
 
  * Membership in the {roles-maintainers} team
  * `Maintainer` status in the {roles-maintainers} team (primary owner only)
  * Write access to the {gh-org}/roles[bisq-network/roles] repository (through the {roles-maintainers} team)
 
-[roles-maintainer-owners]
+[[roles-maintainer-owners]]
 === Owners
 
 See the <<roles-maintainer-role-issue>>

--- a/roles.adoc
+++ b/roles.adoc
@@ -5,14 +5,18 @@ Roles are the means by which responsibility over specific Bisq Network component
 
 == Introduction
 
-The Bisq DAO is a flat organization, with no hierarchical management and reporting infrastructure. At the same time, there are many resources and processes within the Bisq Network that require individuals to take responsibility and to be held accountable for those responsibilities.
+The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many vital resources and processes that must be cared for by individuals. For example, someone must manage the DNS for the https://bisq.network[bisq.network] domain, someone must admininister the {gh-org}[bisq-network] GitHub organization, and so on.
 
-What's needed is a mechanism that defines each of these responsibilities, makes it clear who is responsible for which, and that includes a process for regular reporting and feedback. Roles provide that mechanism.
+And because the Bisq DAO is not a volunteer organization, but one that compensates valuable contributions, it must be possible for stakeholders to assess how these resources and processes are being cared for over time so as to know whether and how much to compensate those in charge of them.
+
+What's needed is a mechanism that defines each of these responsibilities, makes it clear who is responsible for them, and that includes a process for regular reporting and feedback. The system of roles described below provide that mechanism.
 
 
 == Infrastructure
 
 === GitHub
+
+==== Issues
 
 Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] repository.
 
@@ -28,54 +32,96 @@ Roles are managed as issues in the {gh-org}/roles/issues[bisq-network/roles] rep
  - Labels used to
    - Indicate `help wanted`
 
-=== Teams in the bisq-network GitHub organization
+==== Teams
+
 Managed as GitHub Teams. For @mentions and to institutionalize thinking in terms of roles not individuals.
 
 === Docs
 
-==== role documentation
 There is no "role documentation" per se, but rather there is documentation about whatever component or infrastructure a given role is responsible for, and in that documentation, there is a section for the role.
 
 === Slack
 
-.Example
-----
-DNS Admin
-
-Assignees: @cbeams, @ripcurlx
-Description:
-    Team: @bisq-network/dns-admins
-    Primary: @cbeams
-    Docs: https://docs.bisq.network/dns.html#admin
-----
+Slack.
 
 
-
-
-
-== Role ownership
-
-=== primary / secondary role owners
-
-=== Privileges
+== Anatomy of a role
 
 === Duties
 
-==== Reporting
+A role's _duties_ are the activities that the role's owner must carry out in order to be compensated for their efforts. For example, repository maintainers must enforce review process and merge pull requests in a timely fashion, the website operator must keep the site up and running at all times, and so forth.
+
+=== Rights
+
+Most roles involve some special _rights,_ such as exclusive permissions or access to a given resource. For example, a maintainer of a bisq-network GitHub repository will have write permissions to that repository such that they can merge contributors' pull requests, the operator of the bisq.network website will have administrative access to the infrastructure that hosts the site, and so forth.
+
+=== Owners
+
+Each role has one or more _owners,_ with one being designated as _primary_ and others being designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary role owner is responsible for carrying out the day to day activities of that role, while secondary owners are standing by, fully capable of taking over for the primary owner in case of sickness or other incapacitation.
 
 
-== Common Role Types
+== Common role duties
 
-bonded contributor roles
+=== Reporting
 
-maintainer
+=== Communication
 
-operator
+Respond to issues in any repositories
 
-administrator
+Respond to inquiries in Slack
 
-moderator
+Generally means setting up notifications appropriately.
 
+=== Documentation
+
+Specifically, keeping your own role's documentation up to date
+
+
+== Common role types
+
+=== Maintainer
+
+=== Operator
+
+=== Administrator
+
+=== Moderator
+
+
+== Compensation
+
+
+== Bonding
+
+
+== Proceseses
+
+=== Proposing a new role
+
+=== Transferring ownership
+
+=== Changing primary / secondary status
+
+=== Adding a secondary
+
+=== Providing feedback to role owners
+
+
+[roles-maintainer]
+== The Roles Maintainer role
+
+The system of roles described above is a collection of infrastructure and processes like any other in the Bisq DAO, and requires a maintainer to care for it.
+
+https://github.com/bisq-network/roles/issues/28
+
+=== Duties
+
+All normal <<maintainter>>
+
+=== Rights
+
+
+== Notes
 
 replace the proto-documentation we did for roles in the Phase Zero doc, particularly that found at docs.bisq.network/dao/phase-zero.html#bonded-contributor-roles
 
@@ -94,3 +140,18 @@ Update https://docs.bisq.network/dao/phase-zero.html#Appendix-A
 Close https://github.com/bisq-network/bisq-docs/issues/46
 
 Maintainer role must be fully separated from reviewer role. Maintainers validate that pull requests are correct, maintainers ensure that overall process is followed, maintainers give enough time for sufficient review, and then, maintainers merge pull requests. When somone is _reviewing_ a pull request, even if that person is a maintainer, they are not wearing their maintainer hat. They are wearing their _contributor_ hat. Maintainers do not review. See https://github.com/bisq-network/roles/issues/63#issuecomment-393453744 for counter-example of this. Reviewing puts too much on maintainers.
+
+////
+.Example
+----
+DNS Admin
+
+Assignees: @cbeams, @ripcurlx
+Description:
+    Team: @bisq-network/dns-admins
+    Primary: @cbeams
+    Docs: https://docs.bisq.network/dns.html#admin
+----
+////
+
+TIP: Subscribe to individual role issues or watch the entire repository to stay up to date with role reports.

--- a/roles.adoc
+++ b/roles.adoc
@@ -7,10 +7,11 @@ Roles are the way contributors take responsibility for Bisq Network resources an
 
 The Bisq DAO is a flat organization, without traditional management or reporting structures. At the same time, there are many vital resources and processes that must be cared for by individuals. For example, someone must manage the DNS for the `bisq.network` domain, someone must conduct monthly stakeholder voting, and so on.
 
-What's needed is a mechanism that defines these various responsibilities, makes it clear who is responsible for each, and that includes a process for regular reporting and feedback. The system of _roles_ described below provides that mechanism.
+What's needed is a mechanism that defines these various duties, makes it clear who is responsible for each, and that includes a process for regular reporting and feedback. The system of _roles_ described below provides such a mechanism.
 
 
-== Characteristics
+[[characteristics]]
+== Characteristics of a role
 
 === Duties
 
@@ -26,7 +27,7 @@ For example, a repository maintainer's rights include write permissions to their
 
 === Owners
 
-The individuals who have the <<rights>> required to perform the <<duties>> of a role.
+Contributors who have the <<rights>> required to perform the <<duties>> of a role.
 
 One owner is designated as _primary_ and any other owners are designated as _secondary_.footnote:[See {gh-org}/proposals/issues/12] The primary is responsible for performing the <<duties>> of the role, while secondaries stand by, capable of taking over for the primary at any time.
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -66,6 +66,16 @@ There is no "role documentation" per se, but rather there is documentation about
 Slack.
 
 
+== Types
+
+=== Maintainer
+
+=== Operator
+
+=== Administrator
+
+=== Moderator
+
 
 == Common role duties
 
@@ -97,17 +107,6 @@ Generally means setting up notifications appropriately.
 === Documentation
 
 Specifically, keeping your own role's documentation up to date
-
-
-== Common role types
-
-=== Maintainer
-
-=== Operator
-
-=== Administrator
-
-=== Moderator
 
 
 == Compensation

--- a/roles.adoc
+++ b/roles.adoc
@@ -94,6 +94,22 @@ The goal is to have as many competent contributors developing and reviewing as p
 
 === Operator
 
+An _Operator_ is a contributor responsible for keeping a given resource running and functioning normally.
+
+Examples: {role}/19[Forum Operator], {role}/14[Bisq Pricenode Operator]
+
+==== Operator Duties
+
+ * Keep the given resource online and functioning normally.
+ * Keep the resource up to date with latest version.
+ * Maintain backups as appropriate.
+ * Report on any incidents.
+
+==== Operator Rights
+
+ * Administrative access to hosting infrastructure.
+ * Ownership of any domain name used.
+
 === Administrator
 
 === Moderator

--- a/roles.adoc
+++ b/roles.adoc
@@ -127,7 +127,7 @@ The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.fo
 {gh-org}/issues/28[#28]
 
 [roles-maintainer-duties]
-==== Duties
+=== Duties
 
  * Enforce the proposals <<processes>> detailed below.
  * Monitor communications on the `#roles` Slack channel.footnote:[See link:roles.html#communication[]]
@@ -135,12 +135,12 @@ The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.fo
  * Write a monthly report on the roles maintainer <<roles-maintainer-role-issue>>.footnote:[See link:roles.html#reporting[]]
 
 [roles-maintainer-rights]
-==== Rights
+=== Rights
 
  * Write access to the {gh-org}/roles[bisq-network/roles] repository
 
 [roles-maintainer-owners]
-==== Owners
+=== Owners
 
 See the <<roles-maintainer-role-issue>>
 

--- a/roles.adoc
+++ b/roles.adoc
@@ -222,7 +222,9 @@ For example, as mentioned above in the <<maintainer-duties>> section, a reposito
 
 == Bonding
 
-TODO
+Most roles involve special <<rights>> that, if abused, could cause damage to the Bisq Network. For this reason, role owners must put up a _bond_ in BSQ commensurate with the amount of damage that could be caused. In the event of a role owner turning into a bad actor or being grossly negligent, this bond can be confiscated through a BSQ voting process.
+
+Bonding is not currently in place during <<dao/phase-zero#, Phase Zero>> of the Bisq DAO, but is being implemented and will come online when we go live on Bitcoin testnet.
 
 
 [[roles-maintainer-role]]

--- a/roles.adoc
+++ b/roles.adoc
@@ -116,7 +116,7 @@ Specifically, keeping your own role's documentation up to date
 == Bonding
 
 
-== Proceseses
+== Processes
 
 === Proposing a new role
 
@@ -132,12 +132,27 @@ Specifically, keeping your own role's documentation up to date
 [roles-maintainer]
 == The Roles Maintainer role
 
-The system of roles described above is a collection of infrastructure and processes like any other in the Bisq DAO, and requires a maintainer to care for it.
+The contributor(s) responsible for roles <<infrastructure>> and <<processes>>.footnote:[See link:roles.html#maintainer[]]
 
-https://github.com/bisq-network/roles/issues/28
+[roles-maintainer-role-issue]
+=== Role Issue
 
-=== Duties
+{gh-org}/issues/28[#28]
 
-All normal <<maintainter>>
+[roles-maintainer-duties]
+==== Duties
 
-=== Rights
+ * Enforce the proposals <<processes>> detailed below.
+ * Monitor communications on the `#roles` Slack channel.footnote:[See link:roles.html#communication[]]
+ * Keep this roles documentation up to date.footnote:[See link:roles.html#documentation[]]
+ * Write a monthly report on the roles maintainer <<roles-maintainer-role-issue>>.footnote:[See link:roles.html#reporting[]]
+
+[roles-maintainer-rights]
+==== Rights
+
+ * Write access to the {gh-org}/roles[bisq-network/roles] repository
+
+[roles-maintainer-owners]
+==== Owners
+
+See the <<roles-maintainer-role-issue>>

--- a/roles.adoc
+++ b/roles.adoc
@@ -82,7 +82,7 @@ Slack.
 
 === Reporting
 
-Primary role <<owners>> should submit a _monthly report_ as a comment on their role's <<issues,issue>>.footnote:[See {gh-org}/proposals/issues/13] The report should contain whatever information the owner believes would be valuable to other users, contributors and stakeholders. The comment should be formatted in Markdown as follows:
+Primary role <<owners>> should submit a _monthly report_ as a comment on their <<issues, Role Issue>>.footnote:[See {gh-org}/proposals/issues/13] The report should contain whatever information the owner believes would be valuable to other users, contributors and stakeholders. The comment should be formatted in Markdown as follows:
 
 [source,markdown]
 ----

--- a/roles.adoc
+++ b/roles.adoc
@@ -68,6 +68,30 @@ Most roles fit into one of the types below.
 
 === Maintainer
 
+A _Maintainer_ is a contributor responsible for enforcing process in a given GitHub repository.
+
+Examples: {role}/63[Bisq Desktop Maintainer], {role}/30[Proposals Maintainer]
+
+==== Maintainer Duties
+
+ * Merging or closing pull requests after sufficient review.
+ * Tagging releases.
+ * Keeping issues organized and to a minimum.
+
+==== Maintainer Rights
+
+ * Write access to the repository they are responsible for.
+
+[IMPORTANT]
+.A Maintainer is not a Developer or a Reviewer
+====
+The maintainer role is strictly about enforcing process. Development (submitting pull requests) is something any contributor can do. Likewise, review is open to contributors and is NOT the special duty of maintainers.
+
+This is particularly important from a compensation perspective. If you are a maintainer, do NOT group development and review activities under your maintainer role in your compensation requests. Rather, itemize your pull requests and reviews just like any other contributor would.
+
+The goal is to have as many competent contributors developing and reviewing as possible, not to load everything on the Maintiner. https://rfc.unprotocols.org/spec:1/C4/#21-preliminaries[C4] is the inspiration here, it's worth re-reading.
+====
+
 === Operator
 
 === Administrator


### PR DESCRIPTION
Similar to the doc we already have on the [Proposals](https://docs.bisq.network/proposals.html) infrastructure and process, this doc on _Roles_ will capture everything about Roles infrastructure and process under the Bisq DAO.

It will:

 - [x] replace the proto-documentation we did for roles in the Phase Zero doc, particularly that found at https://docs.bisq.network/dao/phase-zero.html#bonded-contributor-roles
 - [x] capture the decisions we've made around roles in bisq-network/proposals#12 and bisq-network/proposals#13 and bisq-network/proposals#14
 - [x] document the way the https://github.com/bisq-network/roles repository works and document the responsibilities of the roles maintainer (bisq-network/roles#28).
 - [x] cover the relationship between role issues, GitHub teams, primary/secondary role owners
 - [x] document, or at least carve out a placeholder for documenting, the way bonding and BSQ interest payments will work for bonded contributor roles.
 - [x] document the process for creating a new role, which will likely involve submitting a _proposal_ for a new role, similar to the way [this one](https://github.com/bisq-network/proposals/issues/15) was done
 - [x] Update https://docs.bisq.network/dao/phase-zero.html#Appendix-A
