### PR TITLE
Add Bitcoin Core Node role doc

### DIFF
--- a/btcnode.adoc
+++ b/btcnode.adoc
@@ -1,15 +1,15 @@
 = Bitcoin Core Nodes
 
-Bisq contributors run a federation of Bitcoin Core nodes to ensure Bisq connects to nodes with consistent Bitcoin Core implementations.
+Bisq contributors run a federation of Bitcoin Core nodes to (1) avoid relying on bloom filters to protect user privacy when connecting to arbitrary public nodes and (2) ensure Bisq connects to nodes with consistent Bitcoin Core implementations.
 
 
 == Introduction
 
 In the past, Bisq connected to arbitrary Bitcoin Core nodes, but the prospect of the SegWit2x hard fork in Fall 2017 made it clear this was not ideal—in the case of a hard fork, it would be impossible for Bisq to tell which fork a connected node was running. The SegWit2x hard fork never happened, but if it did, there was a chance transactions would execute on an undesirable fork, and even worse, a chance that transactions would execute on different forks.
 
-Hence the decision to run a federation of Bitcoin nodes known to run the same Bitcoin Core implementation and configuration—Bisq can expect all bitcoin nodes it connects to enforce consistent block validation rules.
+Critically, bloom filters introduce serious privacy flaws when connecting to arbitrary bitcoin nodes, as chain analysis companies spy on SPV wallets. Connecting only to nodes run by trusted Bisq contributors avoids such monitoring.
 
-An important additional benefit of this setup is added user privacy: bloom filters in bitcoinj are not implemented very well, so connecting only to nodes run by trusted Bisq contributors avoids monitoring from arbitrary public nodes.
+Hence the decision to run a federation of Bitcoin nodes: more robust user privacy and a consistent Bitcoin Core implementation Bisq can rely on.
 
 Note: Bisq users can still choose to connect to arbitrary public nodes, as before, or even connect to specific nodes they prefer.
 
@@ -92,4 +92,4 @@ Set up a Bitcoin Core node, making sure to use the configuration https://github.
 
 === Step 3. Include Node in Bisq Source
 
-Once your node is ready, send a PR to include it as a Bitcoin Core node for Bisq (they're currently specified https://github.com/bisq-network/bisq/blob/ff4e22d5f537ec8e77bffb3fec116b96fa387c46/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java[here]).
+Once your node is ready, send a PR to include it as a Bitcoin Core node for Bisq (they're currently specified https://github.com/bisq-network/bisq/blob/master/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java[here]).

--- a/btcnode.adoc
+++ b/btcnode.adoc
@@ -76,8 +76,6 @@ The contributor(s) responsible for keeping full nodes running as outlined in <<p
 
 == Process
 
-[ the following is a rough outline in need of feedback and with blanks to fill ]
-
 === Step 0. Evaluate
 
 Determine if this is really a role you can fill. It's expected that your node will maintain (1) good uptime and (2) an up-to-date config and bitcoind version (as required by the Bitcoin Node Maintainer). There are no strict requirements for either, but it's expected that you will make your best effort to stay current.
@@ -88,7 +86,7 @@ Contact the Bitcoin Core Maintainer to convey your intention of setting up a Bit
 
 === Step 2. Set it Up
 
-Set up a Bitcoin Core node, making sure to use the configuration https://github.com/bisq-network/bisq-btcnode[specified here] [where is it, actually?]. Also make sure your node runs in a secure environment [ details? ] and that it allows onion connections so Bisq can connect to it.
+Set up a Bitcoin Core node, making sure to use the configuration https://github.com/bisq-network/bisq-btcnode/blob/master/bitcoin.conf[specified here]. Also make sure your node runs in a secure environment (i.e. basic server admin: locked-down user access, security patches applied promptly, etc) and that it allows onion connections so Bisq can connect to it.
 
 === Step 3. Include Node in Bisq Source
 

--- a/btcnode.adoc
+++ b/btcnode.adoc
@@ -1,0 +1,95 @@
+= Bitcoin Core Nodes
+
+Bisq contributors run a federation of Bitcoin Core nodes to ensure Bisq connects to nodes with consistent Bitcoin Core implementations.
+
+
+== Introduction
+
+In the past, Bisq connected to arbitrary Bitcoin Core nodes, but the prospect of the SegWit2x hard fork in Fall 2017 made it clear this was not ideal—in the case of a hard fork, it would be impossible for Bisq to tell which fork a connected node was running. The SegWit2x hard fork never happened, but if it did, there was a chance transactions would execute on an undesirable fork, and even worse, a chance that transactions would execute on different forks.
+
+Hence the decision to run a federation of Bitcoin nodes known to run the same Bitcoin Core implementation and configuration—Bisq can expect all bitcoin nodes it connects to enforce consistent block validation rules.
+
+An important additional benefit of this setup is added user privacy: bloom filters in bitcoinj are not implemented very well, so connecting only to nodes run by trusted Bisq contributors avoids monitoring from arbitrary public nodes.
+
+Note: Bisq users can still choose to connect to arbitrary public nodes, as before, or even connect to specific nodes they prefer.
+
+== Infrastructure
+
+=== GitHub
+
+Issues are managed in the {gh-org}/bisq-btcnode[bisq-network/bisq-btcnode] repository.
+
+=== Slack
+
+Discussion of Bitcoin Core node status and updates takes place in the `#bisq-btcnode` Slack channel.
+
+
+== Roles
+
+
+=== Maintainer
+
+The contributor(s) responsible for full node <<infrastructure>> and <<process>>.footnote:[See link:roles.html#maintainer[]]
+
+==== Role Issue
+
+{gh-org}/roles/issues/66[bisq-network/roles#66] footnote:[See link:roles.html#issue[]]
+
+==== Role Team
+:btcnode-maintainers: {gh-team}/btcnode-maintainers[@bisq-network/btcnode-maintainers]
+
+{btcnode-maintainers} footnote:[See link:roles.html#team[]]
+
+==== Duties
+
+ * Monitor communications on the `#bisq-btcnode` Slack channel.footnote:[See link:roles.html#communication[]]
+ * Keep this documentation up to date (in particular, the <<process>> detailed below).footnote:[See link:roles.html#documentation[]]
+ * Write a monthly report on the Bitcoin Node Maintainer <<role-issue>>.footnote:[See link:roles.html#reporting[]]
+
+==== Rights
+
+ * Write access to the {gh-org}/bisq-btcnode[bisq-network/bisq-btcnode] repository.
+
+=== Operator
+
+The contributor(s) responsible for keeping full nodes running as outlined in <<process>>.footnote:[See link:roles.html#maintainer[]]
+
+==== Role Issue
+
+{gh-org}/roles/issues/67[bisq-network/roles#67] footnote:[See link:roles.html#issue[]]
+
+==== Role Team
+:btcnode-operators: {gh-team}/btcnode-operators[@bisq-network/btcnode-operators]
+
+{btcnode-operators} footnote:[See link:roles.html#team[]]
+
+==== Duties
+
+ * Operate bitcoin nodes as detailed below in <<process>>.
+ * Monitor communications on the `#bisq-btcnode` Slack channel.footnote:[See link:roles.html#communication[]]
+ * Write a monthly report on the Bitcoin Node Operator <<role-issue>>.footnote:[See link:roles.html#reporting[]]
+
+==== Rights
+
+ * N/A
+
+
+== Process
+
+[ the following is a rough outline in need of feedback and with blanks to fill ]
+
+=== Step 0. Evaluate
+
+Determine if this is really a role you can fill. It's expected that your node will maintain (1) good uptime and (2) an up-to-date config and bitcoind version (as required by the Bitcoin Node Maintainer). There are no strict requirements for either, but it's expected that you will make your best effort to stay current.
+
+=== Step 1. Get in Touch
+
+Contact the Bitcoin Core Maintainer to convey your intention of setting up a Bitcoin Core node for Bisq.
+
+=== Step 2. Set it Up
+
+Set up a Bitcoin Core node, making sure to use the configuration https://github.com/bisq-network/bisq-btcnode[specified here] [where is it, actually?]. Also make sure your node runs in a secure environment [ details? ] and that it allows onion connections so Bisq can connect to it.
+
+=== Step 3. Include Node in Bisq Source
+
+Once your node is ready, send a PR to include it as a Bitcoin Core node for Bisq (they're currently specified https://github.com/bisq-network/bisq/blob/ff4e22d5f537ec8e77bffb3fec116b96fa387c46/core/src/main/java/bisq/core/btc/nodes/BtcNodes.java[here]).

--- a/index.adoc
+++ b/index.adoc
@@ -53,6 +53,7 @@ Docs without hyperlinks haven't been written yet. If you want to write one, <<co
  * <<manual-dispute-payout#, How to issue a manual dispute payout>>
  * <<exchange/howto/run-seednode#, How to run a seednode>>
  * <<exchange/howto/run-price-relay-node#, How to run a pricenode>>
+ * <<btcnode#, Bitcoin Node Maintainer Role>>
 
 == Papers
 

--- a/index.adoc
+++ b/index.adoc
@@ -49,11 +49,12 @@ Docs without hyperlinks haven't been written yet. If you want to write one, <<co
  * <<contributor-checklist#, Contributor Checklist>>
  * <<proposals#, Proposals>>
  * <<roles#, Roles>>
+    ** <<btcnode#, Bitcoin Core Node Operator>>
  * <<exchange/howto/list-asset#, How to list an asset>>
  * <<manual-dispute-payout#, How to issue a manual dispute payout>>
  * <<exchange/howto/run-seednode#, How to run a seednode>>
  * <<exchange/howto/run-price-relay-node#, How to run a pricenode>>
- * <<btcnode#, Bitcoin Node Maintainer Role>>
+
 
 == Papers
 

--- a/index.adoc
+++ b/index.adoc
@@ -49,7 +49,7 @@ Docs without hyperlinks haven't been written yet. If you want to write one, <<co
  * <<contributor-checklist#, Contributor Checklist>>
  * <<proposals#, Proposals>>
  * <<roles#, Roles>>
-    ** <<btcnode#, Bitcoin Core Node Operator>>
+    ** <<btcnode#operator, Bitcoin Core Node Operator>>
  * <<exchange/howto/list-asset#, How to list an asset>>
  * <<manual-dispute-payout#, How to issue a manual dispute payout>>
  * <<exchange/howto/run-seednode#, How to run a seednode>>


### PR DESCRIPTION
As discussed [here](https://github.com/bisq-network/roles/issues/66). I'm not sure about some of the details in the Process section, so @sqrrm if you could take a look at that section in particular, it would help.

Once this is done, we should begin making docs for other roles.