### PR TITLE
Embed bisq-dao-in-brief video in user-dao-intro

### DIFF
--- a/css/bisq.css
+++ b/css/bisq.css
@@ -1127,6 +1127,23 @@ a {
     color: #808080;
 }
 
+.videoblock.docs .content {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 30px; height: 0; overflow: hidden;
+    margin-top: 50px;
+    margin-bottom: 50px;
+}
+
+.videoblock.docs .content iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+
 .subheader, .admonitionblock td.content>.title, .audioblock>.title, .exampleblock>.title, .imageblock>.title, .listingblock>.title, .literalblock>.title, .stemblock>.title, .openblock>.title, .paragraph>.title, .quoteblock>.title, table.tableblock>.title, .verseblock>.title, .videoblock>.title, .dlist>.title, .olist>.title, .ulist>.title, .qlist>.title, .hdlist>.title {
     color: #25B135;
 }

--- a/user-dao-intro.adoc
+++ b/user-dao-intro.adoc
@@ -10,6 +10,7 @@ Thus the need for decentralizing the resources in charge of running Bisq itself.
 
 The Bisq project needed infrastructure to provide these functions, and the Bisq DAO is its solution.
 
+video::pNvOZlIDYEQ[youtube]
 
 == What is a DAO?
 


### PR DESCRIPTION
For people who are too impatient to read the doc, there's video right there for them to watch.

If this is good, should we also embed video to the top of [this list doc](https://docs.bisq.network/dao.html)?