### PR TITLE
Update gradle to work with openjdk11

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
It seems Gradle <5.0 doesn't work with OpenJDK 11. This PR upgrades Gradle to v5.6.4, the same version currently used to build the Bisq software.

Intended result is to be able to compile the software and build these docs with the same setup.