### PR TITLE
Update Interac e-Transfer status

### DIFF
--- a/payment-methods.adoc
+++ b/payment-methods.adoc
@@ -71,7 +71,7 @@ CAUTION: The maximum trade sizes listed below are not available for most newly-c
 |{low-risk}
 |
 
-|Interac e-Transfer
+|Interac e-Transfer*
 |Canada
 |1 day
 |{high-risk}


### PR DESCRIPTION
Changed to indicate that Interac e-Transfer does
need Account Signing to lift limits above 0.01 btc.