### PR TITLE
Move asset-listing doc to archive

### DIFF
--- a/archive.adoc
+++ b/archive.adoc
@@ -6,3 +6,4 @@
  * <<exchange/howto/add-alternative-base-currency#, How to add an alternative base currency>>
  * <<manual-dispute-payout#, How to issue a manual dispute payout>>
  * https://docs.google.com/document/d/1DXEVEfk4x1qN6QgIcb2PjZwU4m7W6ib49wCdktMMjLw/edit#heading=h.4nbd0q1s77uq[Bisq arbitration and mediation system] (GDoc)
+ * <<exchange/howto/list-asset#, How to list an asset>>

--- a/exchange/howto/list-asset.adoc
+++ b/exchange/howto/list-asset.adoc
@@ -2,7 +2,12 @@
 :stylesdir: ../../css
 :docinfodir: ../../
 
-IMPORTANT: New asset listings are on hold while a better policy is determined. Please see discussion https://github.com/bisq-network/proposals/issues/166[on this proposal] for background.
+[IMPORTANT]
+--
+**New asset listings are on hold while a better policy is determined**. Please see discussion https://github.com/bisq-network/proposals/issues/166[on this proposal] for background.
+
+Please do not make any further requests to list assets on Bisq.
+--
 
 == Introduction
 

--- a/exchange/howto/list-asset.adoc
+++ b/exchange/howto/list-asset.adoc
@@ -49,7 +49,7 @@ A Bisq arbitrator must be able to look up transactions in the asset's block expl
 
 If your asset meets the prerequisites listed above, you may open a new issue in the bisq-network/bisq repository using this link:
 
-https://github.com/bisq-network/bisq/issues/new?template=new_asset.md[Create issue to request new asset listing^]
+Create issue to request new asset listing [link removed]
 
 **You must use the link above to create the issue, as it links to a template designed specifically for new asset requests.**
 

--- a/index.adoc
+++ b/index.adoc
@@ -68,7 +68,6 @@ image::quick-link-4.png[alt=Make a Compensation Request,width=200,role=quick-lin
 
  * <<contributor-checklist#, Contributor Checklist>> — _The one-stop doc to help you start contributing to Bisq._
  * <<compensation#, Requesting Compensation and Voting>> — _How to get paid for your contributions to Bisq._
- * <<exchange/howto/list-asset#, How to list an asset>> — _Everything you need to know to list an asset on Bisq._
  * <<proposals#, Proposals>>
  * <<roles#, Roles>>
     ** <<btcnode#operator, Bitcoin Core Node Operator>>


### PR DESCRIPTION
To prevent all the new asset listing requests which will not be accommodated anyway under [current policy](https://github.com/bisq-network/proposals/issues/166).

There already was a warning note at the top of the doc saying this, but because requests have continued, it makes sense to make this message more clear by archiving the doc.