### PR TITLE
Redirect "essentials" docs to wiki

### DIFF
--- a/images/external-link-ltr-icon-grey.svg
+++ b/images/external-link-ltr-icon-grey.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="12"
+   height="12"
+   version="1.1"
+   id="svg891"
+   sodipodi:docname="external-link-ltr-icon.svg"
+   inkscape:version="0.92.5 (0.92.5+69)">
+  <metadata
+     id="metadata897">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs895" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2036"
+     id="namedview893"
+     showgrid="false"
+     inkscape:zoom="148.58333"
+     inkscape:cx="6"
+     inkscape:cy="6"
+     inkscape:window-x="0"
+     inkscape:window-y="64"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg891" />
+  <path
+     fill="#fff"
+     stroke="#36c"
+     d="M1.5 4.518h5.982V10.5H1.5z"
+     id="path885"
+     style="stroke:#808080;stroke-opacity:1" />
+  <path
+     fill="#36c"
+     d="M5.765 1H11v5.39L9.427 7.937l-1.31-1.31L5.393 9.35l-2.69-2.688 2.81-2.808L4.2 2.544z"
+     id="path887"
+     style="fill:#808080;fill-opacity:1" />
+  <path
+     fill="#fff"
+     d="M9.995 2.004l.022 4.885L8.2 5.07 5.32 7.95 4.09 6.723l2.882-2.88-1.85-1.852z"
+     id="path889" />
+</svg>

--- a/index.adoc
+++ b/index.adoc
@@ -11,15 +11,15 @@ Many links below redirect to the wiki site, and those that don't will be moved s
 
 === Essentials: Trading on Bisq
 
- * <<intro#, Introduction>> — _Learn what Bisq is, why it exists and how it works_
- * <<getting-started#, Getting Started>> — _Download, set up and start trading with Bisq in minutes_
- * <<secure-wallet#, Wallet Info and Security>> — _Set a password and save your seed words to keep your bitcoin safe_
- * <<backup-recovery#, Backup and Recovery>> — _Maintain backups to keep your settings and history safe_
+ * https://bisq.wiki/Introduction[Introduction] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Learn what Bisq is, why it exists and how it works_
+ * https://bisq.network/getting-started[Getting Started] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Download, set up and start trading with Bisq in minutes_
+ * https://bisq.wiki/Wallet[Wallet Info] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Encrypting_your_wallet[Security] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Set a password and save your seed words to keep your bitcoin safe_
+ * https://bisq.wiki/Backing_up_application_data[Backup] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Restoring_application_data[Recovery] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Maintain backups to keep your settings and history safe_
  * Staying Private — _Maximize control over your personal info and trading data_
- * <<trading-rules#, Trading Rules and Dispute Resolution>> — _Know what's expected of you and others when trading_
- * Fees and Security Deposits — _Understand how your bitcoin is used and kept safe when trading_
+ * https://bisq.wiki/Trading_rules[Trading Rules] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Dispute_resolution[Dispute Resolution] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Know what's expected of you and others when trading_
+ * https://bisq.wiki/Trading_fees[Fees] image:external-link-ltr-icon-grey.svg[external-link,13,13] and Security Deposits — _Understand how your bitcoin is used and kept safe when trading_
  * Support — _Get help from other Bisq users and contributors_
- * <<payment-methods#, Payment Methods>> — _Details on supported fiat currency payment methods and limitations_
+ * https://bisq.wiki/Payment_methods[Payment Methods] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Details on supported fiat currency payment methods and limitations_
  * Altcoins — _Explore https://bisq.network/markets/[100+] supported cryptocurrencies, tokens and assets_
 
 === Bisq DAO: Governing Bisq
@@ -46,7 +46,7 @@ Many links below redirect to the wiki site, and those that don't will be moved s
 
  * <<contributor-checklist#, Contributor Checklist>> — _The one-stop doc to help you start contributing to Bisq._
  * <<compensation#, Requesting Compensation and Voting>> — _How to get paid for your contributions to Bisq._
- * <<proposals#, Proposals>>
+ * https://bisq.wiki/Proposals[Proposals] image:external-link-ltr-icon-grey.svg[external-link,13,13]
  * <<roles#, Roles>>
     ** <<btcnode#operator, Bitcoin Core Node Operator>>
  * <<exchange/howto/run-seednode#, How to run a seednode>>

--- a/index.adoc
+++ b/index.adoc
@@ -11,15 +11,15 @@ Many links below redirect to the wiki site, and those that don't will be moved s
 
 === Essentials: Trading on Bisq
 
- * https://bisq.wiki/Introduction[Introduction] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Learn what Bisq is, why it exists and how it works_
- * https://bisq.network/getting-started[Getting Started] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Download, set up and start trading with Bisq in minutes_
- * https://bisq.wiki/Wallet[Wallet Info] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Encrypting_your_wallet[Security] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Set a password and save your seed words to keep your bitcoin safe_
- * https://bisq.wiki/Backing_up_application_data[Backup] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Restoring_application_data[Recovery] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Maintain backups to keep your settings and history safe_
+ * https://bisq.wiki/Introduction[Introduction^] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Learn what Bisq is, why it exists and how it works_
+ * https://bisq.network/getting-started[Getting Started^] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Download, set up and start trading with Bisq in minutes_
+ * https://bisq.wiki/Wallet[Wallet Info^] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Encrypting_your_wallet[Security^] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Set a password and save your seed words to keep your bitcoin safe_
+ * https://bisq.wiki/Backing_up_application_data[Backup^] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Restoring_application_data[Recovery^] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Maintain backups to keep your settings and history safe_
  * Staying Private — _Maximize control over your personal info and trading data_
- * https://bisq.wiki/Trading_rules[Trading Rules] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Dispute_resolution[Dispute Resolution] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Know what's expected of you and others when trading_
- * https://bisq.wiki/Trading_fees[Fees] image:external-link-ltr-icon-grey.svg[external-link,13,13] and Security Deposits — _Understand how your bitcoin is used and kept safe when trading_
+ * https://bisq.wiki/Trading_rules[Trading Rules^] image:external-link-ltr-icon-grey.svg[external-link,13,13] and https://bisq.wiki/Dispute_resolution[Dispute Resolution^] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Know what's expected of you and others when trading_
+ * https://bisq.wiki/Trading_fees[Fees^] image:external-link-ltr-icon-grey.svg[external-link,13,13] and Security Deposits — _Understand how your bitcoin is used and kept safe when trading_
  * Support — _Get help from other Bisq users and contributors_
- * https://bisq.wiki/Payment_methods[Payment Methods] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Details on supported fiat currency payment methods and limitations_
+ * https://bisq.wiki/Payment_methods[Payment Methods^] image:external-link-ltr-icon-grey.svg[external-link,13,13] — _Details on supported fiat currency payment methods and limitations_
  * Altcoins — _Explore https://bisq.network/markets/[100+] supported cryptocurrencies, tokens and assets_
 
 === Bisq DAO: Governing Bisq
@@ -46,7 +46,7 @@ Many links below redirect to the wiki site, and those that don't will be moved s
 
  * <<contributor-checklist#, Contributor Checklist>> — _The one-stop doc to help you start contributing to Bisq._
  * <<compensation#, Requesting Compensation and Voting>> — _How to get paid for your contributions to Bisq._
- * https://bisq.wiki/Proposals[Proposals] image:external-link-ltr-icon-grey.svg[external-link,13,13]
+ * https://bisq.wiki/Proposals[Proposals^] image:external-link-ltr-icon-grey.svg[external-link,13,13]
  * <<roles#, Roles>>
     ** <<btcnode#operator, Bitcoin Core Node Operator>>
  * <<exchange/howto/run-seednode#, How to run a seednode>>

--- a/index.adoc
+++ b/index.adoc
@@ -2,9 +2,9 @@
 :imagesdir: ./images
 
 [NOTE]
-.These docs are a work in progress (and you can help)
+.These docs are migrating to https://bisq.wiki.
 ====
-Docs without hyperlinks haven't been written yet. If you want to write one, <<contributor-checklist#,let us know>>.
+Many links below redirect to the wiki site, and those that don't will be moved soon.
 ====
 
 == User Docs

--- a/index.adoc
+++ b/index.adoc
@@ -9,28 +9,6 @@ Many links below redirect to the wiki site, and those that don't will be moved s
 
 == User Docs
 
-=== Quick Links
-
-[.float-group]
---
-[.left]
-image::quick-link-1.png[alt=What is Bisq?,width=200,role=quick-link intro]
-//WARNING: links depend on these role labels
-
-[.left]
-image::quick-link-2.png[alt=Start Trading in Minutes,width=200,role=quick-link getting-started]
-//WARNING: links depend on these role labels
-
-[.left]
-image::quick-link-3.png[alt=What is the Bisq DAO?,width=200,role=quick-link dao]
-//WARNING: links depend on these role labels
-
-[.left]
-image::quick-link-4.png[alt=Make a Compensation Request,width=200,role=quick-link compensation]
-//WARNING: links depend on these role labels
---
-
-
 === Essentials: Trading on Bisq
 
  * <<intro#, Introduction>> — _Learn what Bisq is, why it exists and how it works_


### PR DESCRIPTION
This PR redirects docs links to their wiki counterparts. Most of these docs are in the "Essentials" section, as those happen to be the ones already completed on the wiki.

Note that while links to the wiki have an external link icon, they don't open in a new window...but I'm open to feedback if those reviewing this PR think otherwise.

## Review Guidance

An active visual review of the main page of the [preview site](https://deploy-preview-205--bisq-docs.netlify.app) should suffice to review this pull request.

* Look at the commits and verify all changes are on the front page (an image is added, not removed, so there can't possibly be any conflicts introduced)
* f46eb316eca132bf96e2b958aab8fe71f716a374 - does the top admonition box render ok, and is the message good?
* 4b6636b6011c05be2cd13b110f4fd23c99499104 - quick links were removed; does the site show any artifacts or undesirable items as a result?
* d9c65d972f76c781008bd997878a10c1ee6f5c2e - are links correct? are there any other mistakes that cause links to come across as careless or confusing?